### PR TITLE
Use relative paths for the Keras-to-HLS conversion

### DIFF
--- a/example-prjs/demo-conversion/README.md
+++ b/example-prjs/demo-conversion/README.md
@@ -1,0 +1,9 @@
+# Instructions to run
+
+Copy content from the keras-to-hls directory:
+
+```cp -r ../../keras-to-hls/example-keras-model-files ./```
+
+Then run the conversion script:
+
+```python ../../keras-to-hls/keras-to-hls.py -c keras-config.yml```

--- a/example-prjs/demo-conversion/keras-config.yml
+++ b/example-prjs/demo-conversion/keras-config.yml
@@ -1,0 +1,7 @@
+KerasJson: example-keras-model-files/KERAS_3layer_95pruned_retrained.json
+KerasH5:   example-keras-model-files/KERAS_3layer_95pruned_retrained_weights.h5
+OutputDir: my-hls-dir-test
+
+IOType: io_parallel # options: io_serial/io_parallel
+ReuseFactor: 1
+DefaultPrecision: ap_fixed<18,8> 

--- a/hls-template/build_prj.tcl
+++ b/hls-template/build_prj.tcl
@@ -5,8 +5,8 @@
 ############################################################
 open_project -reset myproject_prj
 set_top myproject
-add_files firmware/myproject.cpp -cflags "-I[file normalize ../../nnet_utils]"
-add_files -tb myproject_test.cpp -cflags "-I[file normalize ../../nnet_utils]"
+add_files firmware/myproject.cpp -cflags "-I[file normalize nnet_utils]"
+add_files -tb myproject_test.cpp -cflags "-I[file normalize nnet_utils]"
 add_files -tb firmware/weights
 #add_files -tb tb_data
 open_solution -reset "solution1"

--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -1,14 +1,17 @@
 import tarfile
 import yaml
 from shutil import copyfile
+import os
 
 def hls_writer(layer_list, yamlConfig):
     
     ###################
     ## myproject.cpp
     ###################
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
     
-    f = open('../hls-template/firmware/myproject.cpp','r')
+    f = open(os.path.join(filedir,'../hls-template/firmware/myproject.cpp'),'r')
     fout = open('{}/firmware/myproject.cpp'.format(yamlConfig['OutputDir']),'w')
 
     for line in f.readlines():
@@ -96,7 +99,7 @@ def hls_writer(layer_list, yamlConfig):
     ## parameters.h
     ###################
 
-    f = open('../hls-template/firmware/parameters.h','r')
+    f = open(os.path.join(filedir,'../hls-template/firmware/parameters.h'),'r')
     fout = open('{}/firmware/parameters.h'.format(yamlConfig['OutputDir']),'w')
 
     config_template = """struct config{index} : nnet::layer_config {{
@@ -179,7 +182,7 @@ def hls_writer(layer_list, yamlConfig):
     ## test bench
     ###################
 
-    f = open('../hls-template/myproject_test.cpp','r')
+    f = open(os.path.join(filedir,'../hls-template/myproject_test.cpp'),'r')
     fout = open('{}/myproject_test.cpp'.format(yamlConfig['OutputDir']),'w')
 
     for line in f.readlines():
@@ -197,14 +200,25 @@ def hls_writer(layer_list, yamlConfig):
     f.close()
     fout.close()
 
+    #########################
+    ## adjust include paths
+    #########################
+    f = open(os.path.join(filedir, '../hls-template/build_prj.tcl'),'r')
+    nnetdir = os.path.abspath(os.path.join(filedir, "../nnet_utils"))
+    fout = open(os.path.abspath('{}/build_prj.tcl'.format(yamlConfig['OutputDir'])),'w')
+
+    relpath = os.path.relpath(nnetdir, start=yamlConfig['OutputDir'])
+    for line in f.readlines():
+        newline = line.replace("nnet_utils", relpath)
+        fout.write(newline)
+    f.close()
+    fout.close()
 
     #######################
     ## plain copy of rest
     #######################
-    copyfile('../hls-template/firmware/myproject.h', '{}/firmware/myproject.h'.format(yamlConfig['OutputDir']))
-    copyfile('../hls-template/build_prj.tcl', '{}/build_prj.tcl'.format(yamlConfig['OutputDir']))
-    copyfile('../hls-template/myproject.tcl', '{}/myproject.tcl'.format(yamlConfig['OutputDir']))
-
+    copyfile(os.path.join(filedir, '../hls-template/firmware/myproject.h'), '{}/firmware/myproject.h'.format(yamlConfig['OutputDir']))
+    copyfile(os.path.join(filedir, '../hls-template/myproject.tcl'), '{}/myproject.tcl'.format(yamlConfig['OutputDir']))
 
     #tarball output
     with tarfile.open(yamlConfig['OutputDir'] + '.tar.gz', mode='w:gz') as archive:

--- a/keras-to-hls/keras-to-hls.py
+++ b/keras-to-hls/keras-to-hls.py
@@ -8,7 +8,8 @@ import yaml
 import sys
 from shutil import copyfile
 
-sys.path.insert(0,'../hls-writer/')
+filedir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0,os.path.join(filedir, "..", "hls-writer"))
 from hls_writer import hls_writer
 
 #######################################
@@ -76,7 +77,12 @@ def main():
     args = parser.parse_args()
     if not args.config: parser.error('A configuration file needs to be specified.')
 
+    configDir  = os.path.abspath(os.path.dirname(args.config))
     yamlConfig = parse_config(args.config)
+    yamlConfig['OutputDir'] = os.path.join(configDir, yamlConfig['OutputDir'])
+    yamlConfig['KerasH5'] = os.path.join(configDir, yamlConfig['KerasH5'])
+    yamlConfig['KerasJson'] = os.path.join(configDir, yamlConfig['KerasJson'])
+
     if not (yamlConfig["IOType"] == "io_parallel" or yamlConfig["IOType"] == "io_serial"): 
         raise Exception('ERROR: Invalid IO type')
 

--- a/keras-to-hls/keras-to-hls.py
+++ b/keras-to-hls/keras-to-hls.py
@@ -79,9 +79,12 @@ def main():
 
     configDir  = os.path.abspath(os.path.dirname(args.config))
     yamlConfig = parse_config(args.config)
-    yamlConfig['OutputDir'] = os.path.join(configDir, yamlConfig['OutputDir'])
-    yamlConfig['KerasH5'] = os.path.join(configDir, yamlConfig['KerasH5'])
-    yamlConfig['KerasJson'] = os.path.join(configDir, yamlConfig['KerasJson'])
+    if not os.path.isabs(yamlConfig['OutputDir']):
+        yamlConfig['OutputDir'] = os.path.join(configDir, yamlConfig['OutputDir'])
+    if not os.path.isabs(yamlConfig['KerasH5']):
+        yamlConfig['KerasH5'] = os.path.join(configDir, yamlConfig['KerasH5'])
+    if not os.path.isabs(yamlConfig['KerasJson']):
+        yamlConfig['KerasJson'] = os.path.join(configDir, yamlConfig['KerasJson'])
 
     if not (yamlConfig["IOType"] == "io_parallel" or yamlConfig["IOType"] == "io_serial"): 
         raise Exception('ERROR: Invalid IO type')


### PR DESCRIPTION
Just a small PR that converts the relative paths from keras-config.yml into absolute paths. I ran into this issue when I recently tried to recreate a new project. 

I'm not really wedded to this idea, but it means you can point to the keras-to-hls.py file from elsewhere-- ie not in the "keras-to-hls" folder-- and still get a HLS project that works. It also calculates relative pathing so the HLS project setup points to the nnet_utils folder in the HLS4ML repo.

As an example, I added keras-config.yml to a new "demo-conversion" folder in example-prjs. 

One potential use-case that's not covered here would be if keras-config.yml contains absolute paths rather than relative paths..? 