### PR TITLE
Implement Serial mode directives in Dense Layer

### DIFF
--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -37,7 +37,7 @@ def hls_writer(layer_list, yamlConfig):
                 newline += '    #pragma HLS INTERFACE ap_vld port=data,res \n'
                 newline += '    #pragma HLS PIPELINE \n'
             if yamlConfig["IOType"] == "io_serial":
-                newline += '    #pragma HLS INTERFACE ap_hs port=data,res \n'
+                newline += '    #pragma HLS INTERFACE axis port=data,res \n'
                 newline += '    #pragma HLS DATAFLOW \n'
 
         #Add layers

--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -37,9 +37,8 @@ def hls_writer(layer_list, yamlConfig):
                 newline += '    #pragma HLS INTERFACE ap_vld port=data,res \n'
                 newline += '    #pragma HLS PIPELINE \n'
             if yamlConfig["IOType"] == "io_serial":
-                newline += '    #pragma HLS ARRAY_RESHAPE variable=data complete dim=0 \n'
-                newline += '    #pragma HLS ARRAY_RESHAPE variable=res complete dim=0 \n'
-                newline += '    #pragma HLS INTERFACE ap_vld port=data,res \n'
+                newline += '    #pragma HLS INTERFACE ap_hs port=data,res \n'
+                newline += '    #pragma HLS DATAFLOW \n'
 
         #Add layers
         elif '//hls-fpga-machine-learning insert layers' in line:
@@ -91,7 +90,7 @@ def hls_writer(layer_list, yamlConfig):
                     elif layer_list[i-1]['class_name']=='Conv1D':
                         newline += '    {} layer{}_out[{}*{}];\n'.format(output_type,i,y_out,n_filt)
                     if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=layer{}_out complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=layer{}_out complete dim=0\n'.format(i)
+                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=layer{}_out depth=1\n'.format(i)
 
                 #Compute Dense layer
                 if layer_list[i-1]['activation'] == "linear" and layer_list[i-1]['class_name']=='Dense':
@@ -99,26 +98,26 @@ def hls_writer(layer_list, yamlConfig):
                 elif layer_list[i-1]['class_name']=='Dense':
                     newline += '    {} logits{}[{}];\n'.format(output_type,i,n_out)
                     if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
+                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} depth=1\n'.format(i)
                     newline += '    nnet::compute_layer<{}, {}, config{}>({}, logits{}, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
                 elif layer_list[i-1]['class_name']=='Conv1D':
                     if i>1 and layer_list[i-2]['class_name']=='Conv1D':
                         newline += '    {} conv_layer{}_in[{}][{}];\n'.format(input_type,i,y_in,n_chan)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_in complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_in complete dim=0\n'.format(i)
+                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_in depth=1\n'.format(i)
                         newline += '    nnet::unflatten<{}, {}, {}>({}, conv_layer{}_in);\n'.format(input_type, y_in, n_chan, input_object, i)                              
                         newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
+                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
                         newline += '    nnet::conv_1d<{}, {}, config{}>(conv_layer{}_in, conv_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, i, i, i, i, i)  
                     else:                        
                         newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
+                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
                         newline += '    nnet::conv_1d<{}, {}, config{}>({}, conv_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, input_object, i, i, i, i)
                     newline += '    {} logits{}[{}*{}];\n'.format(output_type,i,y_out,n_filt)
                     if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
+                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
                     newline += '    nnet::flatten<{}, {}, {}>(conv_layer{}_out, logits{});\n'.format(input_type, y_out, n_filt, i, i)
                 
                 #Activations

--- a/keras-to-hls/keras-config.yml
+++ b/keras-to-hls/keras-config.yml
@@ -1,10 +1,10 @@
 KerasJson: example-keras-model-files/KERAS_1layer.json
 KerasH5:   example-keras-model-files/KERAS_1layer_weights.h5
-OutputDir: my-hls-test
+OutputDir: my-hls-test-r1
 ProjectName: myproject
 XilinxPart: xc7vx690tffg1927-2
 ClockPeriod: 5
 
-IOType: io_parallel # options: io_serial/io_parallel
+IOType: io_serial # options: io_serial/io_parallel
 ReuseFactor: 1
 DefaultPrecision: ap_fixed<18,8> 

--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -52,7 +52,9 @@ void  relu(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        // #pragma HLS UNROLL
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         datareg = data[ii];
         if (datareg > 0) res[ii] = datareg;
         else res[ii] = 0;
@@ -68,7 +70,9 @@ void  relu_max(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 
     data_T datareg;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        // #pragma HLS UNROLL
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         datareg = data[ii];
         if (datareg < 0) res[ii] = 0;
         else if (datareg > MAX_INT) res[ii] = MAX_INT;
@@ -121,7 +125,9 @@ void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        // #pragma HLS UNROLL
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         data_round = data[ii]*CONFIG_T::table_size/16;
         index = data_round + 8*CONFIG_T::table_size/16;
         if (index < 0)   index = 0;
@@ -169,7 +175,9 @@ void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        // #pragma HLS UNROLL
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         data_round = data[ii]*CONFIG_T::table_size/16;
         index = data_round + 8*CONFIG_T::table_size/16;
         if (index < 0)   index = 0;
@@ -221,7 +229,9 @@ void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-        // #pragma HLS UNROLL
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         data_round = data[ii]*CONFIG_T::table_size/8;
         index = data_round + 4*CONFIG_T::table_size/8;
         //std::cout << "Input: "  << data[ii] << " Round: " << data_round << " Index: " << index << std::endl;

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -76,8 +76,6 @@ void compute_layer(
 
         // }
     } else if (CONFIG_T::io_type == io_serial){
-        // TODO: Fill out the directives for serial input
-        #pragma HLS ALLOCATION instances=mul limit=CONFIG_T::n_out operation
         #pragma HLS ARRAY_RESHAPE variable=weights complete dim=2
         #pragma HLS ARRAY_PARTITION variable=mult complete dim=2
         #pragma HLS ARRAY_PARTITION variable=acc complete dim=1
@@ -89,10 +87,14 @@ void compute_layer(
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
         if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
+            #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
         }
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
+            if (CONFIG_T::io_type == io_serial) {
+                int multiplier_limit  = ceil(CONFIG_T::n_out / CONFIG_T::reuse_factor);
+                #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
+            }
             mult[ii][jj] = cache * weights[ii][jj];
         }
     }

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -87,12 +87,14 @@ void compute_layer(
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
         if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+  //#pragma HLS PIPELINE II=CONFIG_T::reuse_factor
+            #pragma HLS PIPELINE
         }
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             if (CONFIG_T::io_type == io_serial) {
                 int multiplier_limit  = ceil(CONFIG_T::n_out / CONFIG_T::reuse_factor);
+		if (multiplier_limit < 1) multiplier_limit = 1;
                 #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
             }
             mult[ii][jj] = cache * weights[ii][jj];

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -87,14 +87,13 @@ void compute_layer(
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
         if (CONFIG_T::io_type == io_serial){
-  //#pragma HLS PIPELINE II=CONFIG_T::reuse_factor
             #pragma HLS PIPELINE
         }
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             if (CONFIG_T::io_type == io_serial) {
                 int multiplier_limit  = ceil(CONFIG_T::n_out / CONFIG_T::reuse_factor);
-		if (multiplier_limit < 1) multiplier_limit = 1;
+            if (multiplier_limit < 1) multiplier_limit = 1;
                 #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
             }
             mult[ii][jj] = cache * weights[ii][jj];

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -77,11 +77,20 @@ void compute_layer(
         // }
     } else if (CONFIG_T::io_type == io_serial){
         // TODO: Fill out the directives for serial input
-        // #pragma HLS ALLOCATION instances=mul limit=1 operation
+        #pragma HLS ALLOCATION instances=mul limit=CONFIG_T::n_out operation
+        #pragma HLS ARRAY_RESHAPE variable=weights complete dim=2
+        #pragma HLS ARRAY_PARTITION variable=mult complete dim=2
+        #pragma HLS ARRAY_PARTITION variable=acc complete dim=1
+        #pragma HLS DATAFLOW
+        #pragma HLS STREAM variable=mult depth=1
+        #pragma HLS STREAM variable=acc depth=1
     }
 
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             mult[ii][jj] = cache * weights[ii][jj];
@@ -90,11 +99,17 @@ void compute_layer(
 
     // Initialize accumulator with input biases
     ResetAccum: for(int iacc = 0; iacc < CONFIG_T::n_out; iacc++) {
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS UNROLL
+        }
         acc[iacc] = (typename CONFIG_T::accum_t) biases[iacc];
     }
 
     // Accumulate multiplication result
     Accum1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS PIPELINE
+        }
         Accum2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             acc[jj] += mult[ii][jj];
         }
@@ -102,6 +117,9 @@ void compute_layer(
 
     // Cast to "res_t" type
     Result: for(int ires = 0; ires < CONFIG_T::n_out; ires++){
+        if (CONFIG_T::io_type == io_serial){
+            #pragma HLS UNROLL
+        }
         res[ires] = (res_T) (acc[ires]);
     }    
 }


### PR DESCRIPTION
I saw updates to the recent serial mode PR (https://github.com/hls-fpga-machine-learning/hls4ml/pull/45) -- Looks good!!

I noticed that the top-level IOs were still fully partitioned, and the dense layer directives were too aggressively serialized-- since essentially no directives were applied in serial mode at all, HLS defaults to *everything* being serialized. It's a conservative approach, but generally not very useful from a latency/throughput standpoint  :) 

This PR adds a few edits that make the dense layer in nnet_layer.h somewhat useful in serial mode! I'm pretty happy with how it turned out, and it's pretty close to what I achieved last year in my original library. I think it should be merge-able -- please review / provide feedback otherwise. 

Quick overview of edits:
 1. Removes all ARRAY_RESHAPE / ARRAY_PARTITION directives from the top level. This lets the top-level IOs remain serial inputs and outputs. I also converted the IOs to "handshake" type (ap_hs).
 2. Adds the DATAFLOW directive to the top level,  and corresponding HLS STREAM directives that indicate the variables should be implemented as streaming FIFOs instead of ping-pong ram (https://www.xilinx.com/html_docs/xilinx2017_2/sdaccel_doc/topics/pragmas/ref-pragma_HLS_stream.html)
 3. Set up DATAFLOW, PIPELINE, and ARRAY_PARTITION directives in the dense layer to achieve a "good" balance of resources vs latency for serial mode, including a reasonable usage of the reuse_factor.

Here's a quick overview of my assumptions/expectations for serial-mode:
 - The number of multipliers in the dense layer will be driven by the N_OUT parameter; that is, the matrix-multiply for-loop will be pipelined (by default) such that there are N_OUT parallelized multipliers.
 - The dense layer will be able to accept one new input per clock, perform the matrix multiply, and then clock out one output value at a time. The II for the serialized dense layer should be nominally "close" to the maximum of N_IN and N_OUT (I do see higher IIs, likely due to other glue logic)
 - Adding a reuse_factor will reduce the number of multipliers required for the dense layer, at the expense of a larger II into the matrix multiply. This does not necessarily mean the total II is higher for the dense layer... for example, the 10x32 dense layer in the basic example maintains the same total II when reuse_factor = 2 or 3, because this means it takes 20 or 30 samples to clock in the 10 inputs rather than 10 clocks, but the II was already > 32 because of the output size. 

Utilization result from the basic dense-layer example: 
```
* Summary: 
+-----------------+---------+-------+--------+--------+
|       Name      | BRAM_18K| DSP48E|   FF   |   LUT  |
+-----------------+---------+-------+--------+--------+
|DSP              |        -|      -|       -|       -|
|Expression       |        -|      -|       -|       -|
|FIFO             |        0|      -|      15|      90|
|Instance         |       17|     33|    1781|    3749|
|Memory           |        -|      -|       -|       -|
|Multiplexer      |        -|      -|       -|       -|
|Register         |        -|      -|       9|       -|
+-----------------+---------+-------+--------+--------+
|Total            |       17|     33|    1805|    3839|
+-----------------+---------+-------+--------+--------+
|Available        |     2940|   3600|  866400|  433200|
+-----------------+---------+-------+--------+--------+
|Utilization (%)  |    ~0   |   ~0  |   ~0   |   ~0   |
+-----------------+---------+-------+--------+--------+
```

And the ports show only 18-bit interfaces to data and res: 
```
+-----------------------+-----+-----+------------+----------------+--------------+
|       RTL Ports       | Dir | Bits|  Protocol  |  Source Object |    C Type    |
+-----------------------+-----+-----+------------+----------------+--------------+
|data_V                 |  in |   18|    ap_hs   |     data_V     |    pointer   |
|data_V_ap_vld          |  in |    1|    ap_hs   |     data_V     |    pointer   |
|data_V_ap_ack          | out |    1|    ap_hs   |     data_V     |    pointer   |
|res_V                  | out |   18|    ap_hs   |      res_V     |    pointer   |
|res_V_ap_vld           | out |    1|    ap_hs   |      res_V     |    pointer   |
|res_V_ap_ack           |  in |    1|    ap_hs   |      res_V     |    pointer   |
|const_size_in          | out |   16|   ap_vld   |  const_size_in |    pointer   |
|const_size_in_ap_vld   | out |    1|   ap_vld   |  const_size_in |    pointer   |
|const_size_out         | out |   16|   ap_vld   | const_size_out |    pointer   |
|const_size_out_ap_vld  | out |    1|   ap_vld   | const_size_out |    pointer   |
|ap_clk                 |  in |    1| ap_ctrl_hs |    myproject   | return value |
|ap_rst                 |  in |    1| ap_ctrl_hs |    myproject   | return value |
|ap_start               |  in |    1| ap_ctrl_hs |    myproject   | return value |
|ap_done                | out |    1| ap_ctrl_hs |    myproject   | return value |
|ap_idle                | out |    1| ap_ctrl_hs |    myproject   | return value |
|ap_ready               | out |    1| ap_ctrl_hs |    myproject   | return value |
+-----------------------+-----+-----+------------+----------------+--------------+
```

Timing and Latency also look nice:

```
+ Timing (ns): 
    * Summary: 
    +--------+-------+----------+------------+
    |  Clock | Target| Estimated| Uncertainty|
    +--------+-------+----------+------------+
    |ap_clk  |   5.00|      4.14|        0.62|
    +--------+-------+----------+------------+

+ Latency (clock cycles): 
    * Summary: 
    +-----+-----+-----+-----+----------+
    |  Latency  |  Interval | Pipeline |
    | min | max | min | max |   Type   |
    +-----+-----+-----+-----+----------+
    |   48|   48|   38|   38| dataflow |
    +-----+-----+-----+-----+----------+
```

Thoughts??