### PR TITLE
fix ceil by casting to float first

### DIFF
--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -69,10 +69,10 @@ void conv_1d(
     #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
   
     // Limit multipliers to control parallelization
-    int multiplier_limit = ceil( (CONFIG_T::y_out*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::y_filt - 
-	                          CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_left - 
-                              	  CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_right) 
-	                        / CONFIG_T::reuse_factor ); 
+    int multiplier_limit = ceil( float((CONFIG_T::y_out*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::y_filt - 
+        	                        CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_left - 
+   	                                CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_right)) 
+	                                / float(CONFIG_T::reuse_factor) ); 
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
     

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -70,11 +70,10 @@ void conv_1d(
   
     // Limit multipliers to control parallelization
     int multiplier_limit = ceil( float((CONFIG_T::y_out*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::y_filt - 
-        	                        CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_left - 
-   	                                CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_right)) 
-	                                / float(CONFIG_T::reuse_factor) ); 
+                                        CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_left - 
+                                        CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::pad_right)) 
+                                        / float(CONFIG_T::reuse_factor) ); 
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
-
     
     // Convolve, saving all multiplication results to accumulate later
     ConvOut: for(int ii = 0; ii < CONFIG_T::y_out; ii++) {

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -70,11 +70,9 @@ void compute_layer(
         #pragma HLS ARRAY_PARTITION variable=mult complete
         #pragma HLS ARRAY_PARTITION variable=acc complete
 
-        // if (CONFIG_T::reuse_factor > 1) {
-        int multiplier_limit  = ceil(CONFIG_T::n_in*CONFIG_T::n_out / CONFIG_T::reuse_factor) - floor(CONFIG_T::n_zeros / CONFIG_T::reuse_factor);
+        int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_out) / float(CONFIG_T::reuse_factor)) - floor(float(CONFIG_T::n_zeros) / float(CONFIG_T::reuse_factor));
         #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-        // }
     } else if (CONFIG_T::io_type == io_serial){
         #pragma HLS ARRAY_RESHAPE variable=weights complete dim=2
         #pragma HLS ARRAY_PARTITION variable=mult complete dim=2
@@ -92,8 +90,7 @@ void compute_layer(
         cache = data[ii];
         Product2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
             if (CONFIG_T::io_type == io_serial) {
-                int multiplier_limit  = ceil(CONFIG_T::n_out / CONFIG_T::reuse_factor);
-            if (multiplier_limit < 1) multiplier_limit = 1;
+                int multiplier_limit  = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
                 #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
             }
             mult[ii][jj] = cache * weights[ii][jj];


### PR DESCRIPTION
This fixes a bug in the multiplier limit calculation that was leading to strange initiation intervals (and possibly more).  The "ceil" in the multiplier limit wasn't doing anything because the objects inside were ints.  Now they are cast to float, the ceil does its thing, and we should have enough multipliers to hit the pipeline target.