### PR TITLE
Multiplier limit for conv1d to take advantage of pruning

### DIFF
--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -49,7 +49,7 @@ struct conv_config
 
 
 //Computes number of multiplications required 
-//This function is not synthesized into firmware
+//This function should not be synthesized into firmware
 template<typename CONFIG_T>
 int compute_n_mult(
     typename CONFIG_T::weight_t  weights[CONFIG_T::y_filt * CONFIG_T::n_chan * CONFIG_T::n_filt]
@@ -105,8 +105,8 @@ void conv_1d(
     #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
   
     // Limit multipliers to control parallelization
-    //const int n_mult = compute_n_mult<CONFIG_T>(weights);
-    //const int multiplier_limit = ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
+    const int n_mult = compute_n_mult<CONFIG_T>(weights);
+    const int multiplier_limit = ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
     int multiplier_limit = ceil ( float(compute_n_mult<CONFIG_T>(weights)) / float(CONFIG_T::reuse_factor) );
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
     

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -107,7 +107,6 @@ void conv_1d(
     // Limit multipliers to control parallelization
     const int n_mult = compute_n_mult<CONFIG_T>(weights);
     const int multiplier_limit = ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
-    int multiplier_limit = ceil ( float(compute_n_mult<CONFIG_T>(weights)) / float(CONFIG_T::reuse_factor) );
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
     
     // Convolve, saving all multiplication results to accumulate later

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -48,10 +48,10 @@ struct conv_config
 };
 
 
-//Computes number of multiplications required 
+//Computes multiplier limit
 //This function should not be synthesized into firmware
 template<typename CONFIG_T>
-int compute_n_mult(
+int compute_multiplier_limit(
     typename CONFIG_T::weight_t  weights[CONFIG_T::y_filt * CONFIG_T::n_chan * CONFIG_T::n_filt]
 )
 {
@@ -78,7 +78,7 @@ int compute_n_mult(
 	}//end filter loop
     }//end output loop
 
-    return n_mult;
+    return ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
    
 }//end compute_n_mult
 
@@ -105,8 +105,7 @@ void conv_1d(
     #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
   
     // Limit multipliers to control parallelization
-    const int n_mult = compute_n_mult<CONFIG_T>(weights);
-    const int multiplier_limit = ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
+    const int multiplier_limit = compute_multiplier_limit<CONFIG_T>(weights);
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
     
     // Convolve, saving all multiplication results to accumulate later

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -68,7 +68,7 @@ int compute_multiplier_limit(
 			//padded -- do nothing
                     }
                     else {
-			//need to tune this cut
+			//need to tune this cut?
                         if( weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20 ){
 			    n_mult++;
 			}//end if nonzero weight

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -66,6 +66,7 @@ int compute_multiplier_limit(
                     
                     if((ii*CONFIG_T::stride+jj) < CONFIG_T::pad_left || (ii*CONFIG_T::stride+jj) >= (CONFIG_T::pad_left + CONFIG_T::y_in)){
 			//padded -- do nothing
+			continue;
                     }
                     else {
 			//need to tune this cut?


### PR DESCRIPTION
Add new function to `nnet_conv.h` called `compute_multiplier_limit` that computes the multiplier limit to take advantage of padding and pruning.

Discussed in #56 

Perhaps the one other thing to note is that zero weights are detected with
```
if( weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20 ){
```
This is different from how we have done it with the fully connected layers.   In that case we check if the weight `==0` at full precision in python [here](https://github.com/hls-fpga-machine-learning/hls4ml/blob/master/keras-to-hls/keras-to-hls.py#L33).  Here we don't use the boolean expression, and we look at the weight at ap_fixed precision.
