### PR TITLE
Making the LUT table static

### DIFF
--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -137,8 +137,9 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     // Initialize the lookup table
-    typename CONFIG_T::table_t sigmoid_table[CONFIG_T::table_size];
-    init_sigmoid_table<CONFIG_T, CONFIG_T::table_size>(sigmoid_table);
+    static typename CONFIG_T::table_t sigmoid_table[CONFIG_T::table_size] ={-999.};
+    if(sigmoid_table[0] == -999.)
+      init_sigmoid_table<CONFIG_T, CONFIG_T::table_size>(sigmoid_table);
 
     if (CONFIG_T::io_type == io_parallel){
         #pragma HLS PIPELINE
@@ -198,11 +199,13 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     // Initialize the lookup table
-    typename CONFIG_T::table_t exp_table[CONFIG_T::table_size];
-    init_exp_table<CONFIG_T, CONFIG_T::table_size>(exp_table);
+    static typename CONFIG_T::table_t exp_table[CONFIG_T::table_size] = {-999.};
+    if (exp_table[0] == -999)
+      init_exp_table<CONFIG_T, CONFIG_T::table_size>(exp_table);
 
-    typename CONFIG_T::table_t invert_table[CONFIG_T::table_size];
-    init_invert_table<CONFIG_T, CONFIG_T::table_size>(invert_table);
+    static typename CONFIG_T::table_t invert_table[CONFIG_T::table_size] = {-999.};
+    if (invert_table[0] == -999)
+      init_invert_table<CONFIG_T, CONFIG_T::table_size>(invert_table);
 
     if (CONFIG_T::io_type == io_parallel){
         // Note: This is going to be a resource hog to run with pipeline, but hey, whatever
@@ -270,8 +273,9 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     // Initialize the lookup table
-    typename CONFIG_T::table_t tanh_table[CONFIG_T::table_size];
-    init_tanh_table<CONFIG_T, CONFIG_T::table_size>(tanh_table);
+    static typename CONFIG_T::table_t tanh_table[CONFIG_T::table_size]={-999.};
+    if(tanh_table[0] == -999.)
+      init_tanh_table<CONFIG_T, CONFIG_T::table_size>(tanh_table);
 
     if (CONFIG_T::io_type == io_parallel){
         #pragma HLS PIPELINE


### PR DESCRIPTION
For the activation function, the initiation of LUT is taking too much CPU time
during csim. To fix this issue, change the table to be a static varibles, which will
remain in memory for the running lifetime. Also only call the initiation function by
checking the table value, making the initiation function got called only once.