### PR TITLE
Ap fixed omode

### DIFF
--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -314,7 +314,7 @@ def hls_writer(layer_list, yamlConfig):
             for i in range(1,len(layer_list)):
             #    if layer_list[i-1]['class_name']=='Dense':
             #        newline += 'typedef {precision} layer{index}_t;\n'.format(precision=yamlConfig["DefaultPrecision"], index=i)
-                newline += 'typedef {precision} layer{index}_t;\n'.format(precision=yamlConfig["DefaultPrecision"], index=i)
+                newline += 'typedef {precision} layer{index}_t;\n'.format(precision=yamlConfig["DefaultPrecision"][:-1]+", AP_TRN_ZERO, AP_SAT>", index=i)
 
         elif "//hls-fpga-machine-learning insert layer-config" in line:
             newline = line

--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -137,9 +137,15 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     // Initialize the lookup table
-    static typename CONFIG_T::table_t sigmoid_table[CONFIG_T::table_size] ={-999.};
-    if(sigmoid_table[0] == -999.)
+    static bool initialized = false;
+    static typename CONFIG_T::table_t sigmoid_table[CONFIG_T::table_size];
+    if (!initialized)
+    {
       init_sigmoid_table<CONFIG_T, CONFIG_T::table_size>(sigmoid_table);
+      initialized = true;
+    }
+
+    if(sigmoid_table[0] == CONFIG_T::table_dummy)
 
     if (CONFIG_T::io_type == io_parallel){
         #pragma HLS PIPELINE
@@ -198,14 +204,16 @@ void init_invert_table(typename CONFIG_T::table_t table_out[N_TABLE])
 template<class data_T, class res_T, typename CONFIG_T>
 void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
+    static bool initialized = false;
     // Initialize the lookup table
-    static typename CONFIG_T::table_t exp_table[CONFIG_T::table_size] = {-999.};
-    if (exp_table[0] == -999)
+    static typename CONFIG_T::table_t exp_table[CONFIG_T::table_size];
+    static typename CONFIG_T::table_t invert_table[CONFIG_T::table_size];
+    if (!initialized)
+    {
       init_exp_table<CONFIG_T, CONFIG_T::table_size>(exp_table);
-
-    static typename CONFIG_T::table_t invert_table[CONFIG_T::table_size] = {-999.};
-    if (invert_table[0] == -999)
       init_invert_table<CONFIG_T, CONFIG_T::table_size>(invert_table);
+      initialized = true;
+    }
 
     if (CONFIG_T::io_type == io_parallel){
         // Note: This is going to be a resource hog to run with pipeline, but hey, whatever
@@ -273,9 +281,13 @@ template<class data_T, class res_T, typename CONFIG_T>
 void  tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 {
     // Initialize the lookup table
-    static typename CONFIG_T::table_t tanh_table[CONFIG_T::table_size]={-999.};
-    if(tanh_table[0] == -999.)
+    static bool initialized = false;
+    static typename CONFIG_T::table_t tanh_table[CONFIG_T::table_size];
+    if (!initialized)
+    {
       init_tanh_table<CONFIG_T, CONFIG_T::table_size>(tanh_table);
+      initialized=true;
+    }
 
     if (CONFIG_T::io_type == io_parallel){
         #pragma HLS PIPELINE


### PR DESCRIPTION
The default ap_fixed has the overflow mode as AP_WRAP, which will
cause the number to change significantly from original input.

For example, with the initial value of 8.99, the default ap_fixed<10,4> will
cast it to  -7.01563, while the new ap_fixed<10, 4, AP_TRN_ZERO, AP_SAT> will
cast it to 7.98438.

The change of ap_fixed type only apply to the node output of each layer for now,
to prevent overflow during the run time. The weights and bias are still stored as
default input type. The resource usage remain the same from this type change.