### PR TITLE
Bug fixes for unflatten conv2d and keras to hls conversion

### DIFF
--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -97,7 +97,7 @@ def hls_writer(layer_list, yamlConfig):
                     in_width = 'IN_WIDTH_{}'.format(i)
                     n_chan = 'N_CHAN_{}'.format(i)
                 #Layer is Conv2D
-                elif layer_list[i-1]['class_name']=='Conv1D':
+                elif layer_list[i-1]['class_name']=='Conv2D':
                     input_type = 'layer{}_t'.format(i-1)
                     input_object = 'layer{}_out'.format(i-1)
                     in_height = 'IN_HEIGHT_{}'.format(i)
@@ -196,12 +196,12 @@ def hls_writer(layer_list, yamlConfig):
                         newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
                         if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_1d<{}, {}, config{}>(conv_layer{}_in, conv_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, i, i, i, i, i)  
+                        newline += '    nnet::conv_1d<{}, {}, config{}>(conv_layer{}_in, conv_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, i, i, i, i, i)  
                     else:                        
                         newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
                         if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_1d<{}, {}, config{}>({}, conv_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, input_object, i, i, i, i)
+                        newline += '    nnet::conv_1d<{}, {}, config{}>({}, conv_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
                     newline += '    {} logits{}[{}*{}];\n'.format(output_type,i,y_out,n_filt)
                     if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
                     if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
@@ -215,16 +215,16 @@ def hls_writer(layer_list, yamlConfig):
                         newline += '    {} conv2d_layer{}_out[{}][{}][{}];\n'.format(output_type,i,out_height,out_width,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv2d_layer{}_out complete dim=0\n'.format(i)
                         if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv2d_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_2d<{}, {}, config{}>(conv2d_layer{}_in, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, i, i, i, i, i)  
+                        newline += '    nnet::conv_2d<{}, {}, config{}>(conv2d_layer{}_in, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, i, i, i, i, i)  
                     else:                        
                         newline += '    {} conv2d_layer{}_out[{}][{}][{}];\n'.format(output_type,i,out_height,out_width,n_filt)
                         if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv2d_layer{}_out complete dim=0\n'.format(i)
                         if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv2d_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_2d<{}, {}, config{}>({}, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, input_type, i, input_object, i, i, i, i)
+                        newline += '    nnet::conv_2d<{}, {}, config{}>({}, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
                     newline += '    {} logits{}[{}*{}*{}];\n'.format(output_type,i,out_height,out_width,n_filt)
                     if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
                     if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
-                    newline += '    nnet::flatten<{}, {}, {}, {}>(conv2d_layer{}_out, logits{});\n'.format(input_type, out_height, out_width, n_filt, i, i)
+                    newline += '    nnet::flatten<{}, {}, {}, {}>(conv2d_layer{}_out, logits{});\n'.format(output_type, out_height, out_width, n_filt, i, i)
 
                 
                 #Activations

--- a/keras-to-hls/keras-to-hls.py
+++ b/keras-to-hls/keras-to-hls.py
@@ -16,6 +16,14 @@ filedir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0,os.path.join(filedir, "..", "hls-writer"))
 from hls_writer import parse_config, print_array_to_cpp, hls_writer
 
+def find_kernel_in_h5(name):
+    if 'kernel' in name:
+        return name
+
+def find_bias_in_h5(name):
+    if 'bias' in name:
+        return name
+
 ############################################################################################
 ## M A I N
 ############################################################################################
@@ -107,8 +115,10 @@ def main():
                 #print("PARSED NUM OF NODES",config_value)
 
         #Translate weights and biases from h5 file
-        weights = h5File['/{}/{}/kernel:0'.format(layer['name'],layer['name'])][()]
-        biases = h5File['/{}/{}/bias:0'.format(layer['name'],layer['name'])][()]
+        found_weights = h5File[layer['name']].visit(find_kernel_in_h5)
+        weights = h5File['/{}/{}'.format(layer['name'],found_weights)][()]
+        found_bias = h5File[layer['name']].visit(find_bias_in_h5)
+        biases = h5File['/{}/{}'.format(layer['name'],found_bias)][()]
         cur_n_zeros = print_array_to_cpp("w{}".format(layer_counter), weights, yamlConfig['OutputDir'])
         print_array_to_cpp("b{}".format(layer_counter), biases, yamlConfig['OutputDir'])
         layer['weights_n_zeros'] = cur_n_zeros 

--- a/nnet_utils/nnet_conv2d.h
+++ b/nnet_utils/nnet_conv2d.h
@@ -244,8 +244,8 @@ template<class data_T, int N1, int N2, int N3>
 {
     for(int i1=0; i1<N1; i1++){
       for(int i2=0; i2<N2; i2++){
-        for(int i3=0; i2<N3; i3++){
-             res[i1][i2][i3] = data[i1*N2*N3+i2*N3+i3];
+        for(int i3=0; i3<N3; i3++){
+	    res[i1][i2][i3] = data[i1*N2*N3+i2*N3+i3];
         }//i3
       }//i2
     }//i1  


### PR DESCRIPTION
A few fixes for bugs uncovered trying to Csim @pierinim's model:
1. gets around appended paths to weights in h5 file when using jupyter
1. fix typo in unflatten
2. fix some bugs in hls-writer for choosing input names and types

We can Csim @pierinim's "NoConcatenate" model now, but Csynth will require the sublayer functionality.