### PR TITLE
Fix dense layer instantiation for io_serial mode

### DIFF
--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -233,12 +233,11 @@ void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
     // Index into the lookup table based on data for exponentials
     typename CONFIG_T::table_t exp_res[CONFIG_T::n_in];// different, independent, fixed point precision
     typename CONFIG_T::table_t exp_diff_res[CONFIG_T::n_in][CONFIG_T::n_in];// different, independent, fixed point precision
+    data_T data_cache[CONFIG_T::n_in];
     int data_round;
     int index;
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
-      if (CONFIG_T::io_type == io_serial){
-            #pragma HLS UNROLL
-      }
+      data_cache[ii] = data[ii];
       exp_res[ii] = 0;
     }
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
@@ -248,7 +247,7 @@ void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
         }
 	if (ii==jj) exp_diff_res[ii][jj] = 1;
 	else {
-	  data_round = (data[jj]-data[ii])*CONFIG_T::table_size/16;
+	  data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;
 	  index = data_round + 8*CONFIG_T::table_size/16;
 	  if (index < 0)   index = 0;
 	  if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;

--- a/nnet_utils/nnet_layer.h
+++ b/nnet_utils/nnet_layer.h
@@ -74,9 +74,10 @@ void compute_layer(
         #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
     } else if (CONFIG_T::io_type == io_serial){
-        #pragma HLS ARRAY_RESHAPE variable=weights complete dim=1
-        #pragma HLS ARRAY_PARTITION variable=mult complete dim=1
-        #pragma HLS ARRAY_PARTITION variable=acc complete dim=1
+        unsigned int cycle_factor = CONFIG_T::n_out;
+        #pragma HLS ARRAY_PARTITION variable=weights cyclic factor=cycle_factor
+        #pragma HLS ARRAY_PARTITION variable=mult cyclic factor=cycle_factor
+        #pragma HLS ARRAY_PARTITION variable=acc complete
         #pragma HLS DATAFLOW
         #pragma HLS STREAM variable=mult depth=1
         #pragma HLS STREAM variable=acc depth=1


### PR DESCRIPTION
A few things needed to make serial mode work well for dense layers:
1. Partition the "flattened" weight vector correctly
2. Edit the softmax operation in serial mode so it accesses the input in sequential order
3. Add a RESOURCE directive to instantiate weights into BRAMs if requested

As best as I can tell, the 1layer and 3layer example projects are working well with these updates. Item 2 *should* be compatible with parallel mode -- but I have not gotten a chance to test this yet so I'll take an action to exercise softmax with io_parallel before the PR gets merged. 

The end result appears to be working as expected and completes both the synthesis and RTL simulation successfully... Honestly, the performance vs resource tradeoffs we can evaluate using the reuse_factor is WAY better than anything I had in the old RFNOC repo :) 