### PR TITLE
Automated testing: Add io_serial tests for 1layer and 3layer networks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,8 @@ pipeline {
             dir(path: 'test') {
               sh '''#!/bin/bash
                  . activate hls4ml-py36
-                 cat keras-models.txt | xargs ./keras-to-hls.sh -p 3'''
+                 cat keras-models.txt | xargs ./keras-to-hls.sh -p 3
+                 cat keras-models-serial.txt | xargs ./keras-to-hls.sh -p 3 -s'''
             }
           }
         }
@@ -25,7 +26,8 @@ pipeline {
             dir(path: 'test') {
               sh '''#!/bin/bash
                  . activate hls4ml-py27
-                 cat keras-models.txt | xargs ./keras-to-hls.sh -p 2'''
+                 cat keras-models.txt | xargs ./keras-to-hls.sh -p 2
+                 cat keras-models-serial.txt | xargs ./keras-to-hls.sh -p 2 -s'''
             }
           }
         }

--- a/test/keras-models-serial.txt
+++ b/test/keras-models-serial.txt
@@ -1,0 +1,2 @@
+KERAS_1layer
+KERAS_3layer

--- a/test/keras-to-hls.sh
+++ b/test/keras-to-hls.sh
@@ -85,12 +85,12 @@ do
 
    echo "Creating config file for model '${model}'"
    base=`echo "${h5}" | sed -e 's/\(_weights\)*$//g'`
-   file="${basedir}/${base}-${pycmd}.yml"
+   file="${basedir}/${base}-${pycmd}-${io}.yml"
 
    # This scheme assumes base output directory is one level deep 
    echo "KerasJson: ../../keras-to-hls/example-keras-model-files/${name}.json" > ${file}
    echo "KerasH5:   ../../keras-to-hls/example-keras-model-files/${h5}.h5" >> ${file}
-   echo "OutputDir: ${base}-${pycmd}" >> ${file}
+   echo "OutputDir: ${base}-${pycmd}-${io}" >> ${file}
    echo "ProjectName: myproject" >> ${file}
    echo "XilinxPart: ${xilinxpart}" >> ${file}
    echo "ClockPeriod: ${clock}" >> ${file}


### PR DESCRIPTION
A modest change that simply adds a few serial mode tests. I first tried to include the options as a new line in the keras-models.txt file (like, "KERAS_1layer -s") but this was not compatible with the Jenkins xargs and bash scripts... I ended up using a new text file for serial mode and adding a new command to the Jenkinsfile to read in the new file. 

I needed to append io type onto the "vivado_prj" sub-folder in order to not conflict with the parallel mode test. I was able to run the serial mode tests correctly without failures. 

One thing to mention: when I first tried to run through all test cases, my run did not finish after 24 hours-- is this expected behavior right now? Seems to be slowing down on some of the larger serial mode tests. I'm trying again tonight to see if it was some kind of mistake and I'll save the logs to review this time...
