### PR TITLE
Add workaround for unsupported TCL command in build_prj.tcl

### DIFF
--- a/hls-template/build_prj.tcl
+++ b/hls-template/build_prj.tcl
@@ -21,7 +21,7 @@ add_files -tb myproject_test.cpp -cflags "-I[file normalize nnet_utils]"
 add_files -tb firmware/weights
 #add_files -tb tb_data
 open_solution -reset "solution1"
-config_array_partition -maximum_size 4096
+catch {config_array_partition -maximum_size 4096}
 set_part {xc7vx690tffg1927-2}
 create_clock -period 5 -name default
 


### PR DESCRIPTION
With this change, the `build_prj.tcl` script won't fail on Vivado HLS <2018.1. Discussed in #100.