### PR TITLE
softmax: Move the HLS PIPELINE command into the outer loop

### DIFF
--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -238,10 +238,10 @@ void  softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
       exp_res[ii] = 0;
     }
     for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+      if (CONFIG_T::io_type == io_serial){
+          #pragma HLS PIPELINE
+      }
       for (int jj=0; jj<CONFIG_T::n_in; jj++) {
-        if (CONFIG_T::io_type == io_serial){
-            #pragma HLS PIPELINE
-        }
 	if (ii==jj) exp_diff_res = 1;
 	else {
 	  data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;


### PR DESCRIPTION
I ran into a few issues with PIPELINE in the inner loop. Basically,
I could not meet timing for the device I was simulating (xc7z020clg484-1)
for the keras_3layer example, and the critical path traced back to
the exp_diff_res lookup and accumulate. With some empiprical testing,
I found moving HLS PIPELINE to the outer loop gets much better results:

1. Timing improved from a min of 6.6 ns to 4.32
2. Latency reduced in the softmax from 106 to 70 (likely driven by size of the softmax input)
3. Other resource usage stayed pretty similar. A big more usage in softmax, but OK overall

This should only impact serial mode