### PR TITLE
Add timing to the build step

### DIFF
--- a/hls-template/build_prj.tcl
+++ b/hls-template/build_prj.tcl
@@ -14,6 +14,14 @@ foreach arg $::argv {
   }
 }
 
+proc report_time { op_name time_start time_end } {
+  set time_taken [expr $time_end - $time_start]
+  set time_s [expr ($time_taken / 1000) % 60]
+  set time_m [expr ($time_taken / (1000*60)) % 60]
+  set time_h [expr ($time_taken / (1000*60*60)) % 24]
+  puts "***** ${op_name} COMPLETED IN ${time_h}h${time_m}m${time_s}s *****"
+}
+
 open_project -reset myproject_prj
 set_top myproject
 add_files firmware/myproject.cpp -cflags "-I[file normalize nnet_utils]"
@@ -27,19 +35,31 @@ create_clock -period 5 -name default
 
 if {$opt(csim)} {
   puts "***** C SIMULATION *****"
+  set time_start [clock clicks -milliseconds]
   csim_design
+  set time_end [clock clicks -milliseconds]
+  report_time "C SIMULATION" $time_start $time_end  
 }
 
 if {$opt(synth)} {
   puts "***** C/RTL SYNTHESIS *****"
+  set time_start [clock clicks -milliseconds]
   csynth_design
+  set time_end [clock clicks -milliseconds]
+  report_time "C/RTL SYNTHESIS" $time_start $time_end
   if {$opt(cosim)} {
     puts "***** C/RTL SIMULATION *****"
+    set time_start [clock clicks -milliseconds]
     cosim_design -trace_level all
+    set time_end [clock clicks -milliseconds]
+    report_time "C/RTL SIMULATION" $time_start $time_end
   }
   if {$opt(export)} {
     puts "***** EXPORT IP *****"
+    set time_start [clock clicks -milliseconds]
     export_design -format ip_catalog
+    set time_end [clock clicks -milliseconds]
+    report_time "EXPORT IP" $time_start $time_end
   }
 }
 

--- a/hls-template/build_prj.tcl
+++ b/hls-template/build_prj.tcl
@@ -10,7 +10,7 @@ array set opt {
 
 foreach arg $::argv {
   foreach o [lsort [array names opt]] {
-    regexp "$o +(\\w+)" $arg unused opt($o)
+    regexp "$o=+(\\w+)" $arg unused opt($o)
   }
 }
 

--- a/test/build-prj.sh
+++ b/test/build-prj.sh
@@ -5,10 +5,10 @@ vivadodir=/opt/Xilinx
 vivadover=2017.2
 parallel=1
 
-csim="csim 0"
-synth="synth 0"
-cosim="cosim 0"
-export="export 0"
+csim="csim=0"
+synth="synth=0"
+cosim="cosim=0"
+export="export=0"
 
 function print_usage {
    echo "Usage: `basename $0` [OPTION]"
@@ -73,15 +73,15 @@ while getopts ":d:i:v:p:csreh" opt; do
       ;;
    p) parallel=$OPTARG
       ;;
-   c) csim="csim 1"
+   c) csim="csim=1"
       ;;
-   s) synth="synth 1"
+   s) synth="synth=1"
       ;;
-   r) cosim="cosim 1"
-      synth="synth 1"
+   r) cosim="cosim=1"
+      synth="synth=1"
       ;;
-   e) export="export 1"
-      synth="synth 1"
+   e) export="export=1"
+      synth="synth=1"
       ;;
    h)
       print_usage


### PR DESCRIPTION
Mentioned in the last meeting, discussed with @nhanvtran. This times sim, synth, cosim and export phase of the `build_prj.tcl` script and displays elapsed time in human-readable form (hours, minutes and seconds).
