### PR TITLE
Long latency in ternary tanh due to comparison with fractional number

### DIFF
--- a/nnet_utils/nnet_activation.h
+++ b/nnet_utils/nnet_activation.h
@@ -692,9 +692,9 @@ void  ternary_tanh(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
   if (CONFIG_T::io_type == io_serial){
       #pragma HLS PIPELINE
   }
-  datareg = data[ii];	 
-  if( datareg > 0.5 ) cache = 1;
-  else if( datareg > -0.5 && datareg <= 0.5) cache=0;
+  datareg = 2*data[ii];	 
+  if( datareg > 1 ) cache = 1;
+  else if( datareg > -1 && datareg <= 1) cache=0;
   else cache = -1;
   
   res[ii] = (res_T) cache;


### PR DESCRIPTION
I noticed that after the fix to the ternary tanh activation function in this commit

https://github.com/hls-fpga-machine-learning/hls4ml/pull/114/commits/e81e98bc128bc15c6e650c4f6350073a7cec66be

the latency for the activation function operation increased from 0 to 7 clock cycles.
It seems it is due to the comparison with a fraction number (0.5 in this case).
In this PR I changed such that the data are multiplied by 2 and the comparison is done with 1. This change brings the latency for the ternary tanh back to 0.

