### PR TITLE
Valid padding in pooling layers can cause OOB errors

### DIFF
--- a/nnet_utils/nnet_pooling.h
+++ b/nnet_utils/nnet_pooling.h
@@ -140,8 +140,12 @@ void pooling2d(data_T data[CONFIG_T::in_height][CONFIG_T::in_width][CONFIG_T::n_
   const int limit = pool_op_limit<CONFIG_T>();
   #pragma HLS ALLOCATION instances=pool_op limit=limit function
   // Add any necessary padding
-  const unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
-  const unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+  unsigned padded_height = CONFIG_T::in_height + CONFIG_T::pad_top + CONFIG_T::pad_bottom;
+  unsigned padded_width = CONFIG_T::in_width + CONFIG_T::pad_left + CONFIG_T::pad_right;
+  if (CONFIG_T::pad_top == 0 && CONFIG_T::pad_bottom == 0 && CONFIG_T::pad_left == 0 && CONFIG_T::pad_right == 0) {
+    padded_height -= padded_height - (padded_height / CONFIG_T::stride_height * CONFIG_T::stride_height);
+    padded_width -= padded_width - (padded_width / CONFIG_T::stride_width * CONFIG_T::stride_width);
+  }
 
   for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
 	  // Loop over input image y in steps of stride


### PR DESCRIPTION
E.g., in a MaxPooling2D layer with pool size `2x2` and stride `2x2` on a `5x5` input the last row/column should be dropped. Otherwise, we can have out-of-bounds array access. Observed in model received from Luigi & Simone.

```
ERROR: [XFORM 203-103] Cannot partition array 'pool2d_layer2_out.V' (firmware/mininet_CMDrFDeDe.cpp:77): array access out of bound (/home/hls4ml/FPGA/hls4ml_luigi/nnet_utils/nnet_pooling.h:171:8).
ERROR: [HLS 200-70] Pre-synthesis failed.
command 'ap_source' returned error code
    while executing
"source [lindex $::argv 1] "
    ("uplevel" body line 1)
    invoked from within
"uplevel \#0 { source [lindex $::argv 1] } "

```
Adding the simple check and dropping the extra rows/columns did not seem to affect latency.