### PR TITLE
batch norm precision fix

### DIFF
--- a/nnet_utils/nnet_batchnorm.h
+++ b/nnet_utils/nnet_batchnorm.h
@@ -85,10 +85,10 @@ void normalize(
             #pragma HLS UNROLL
             #pragma HLS PIPELINE
         }
-        if(CONFIG_T::n_filt==-1) res[ires] = (res_T) (data[ires]-mean[ires])*scale[ires]+beta[ires];
+        if(CONFIG_T::n_filt==-1) res[ires] = (data[ires]-mean[ires])*scale[ires]+beta[ires];
 	else{
 	 int norm_index = ires%CONFIG_T::n_filt;
-	 res[ires] = (res_T) (data[ires]-mean[norm_index])*scale[norm_index]+beta[norm_index];
+	 res[ires] = (data[ires]-mean[norm_index])*scale[norm_index]+beta[norm_index];
 	}
     }   
        


### PR DESCRIPTION
Fixed Issue #133 caused by casting having higher precedence than expected.  This PR removes the casting (adding parentheses would also work).