### PR TITLE
HLS writer (& others) rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__
 vivado_prj
+.vscode

--- a/example-prjs/conv-1layer/firmware/myproject.cpp
+++ b/example-prjs/conv-1layer/firmware/myproject.cpp
@@ -76,7 +76,7 @@ void myproject(
     //Dense
     result_t logits2[N_OUTPUTS];
     #pragma HLS ARRAY_PARTITION variable=logits2 complete dim=0
-    nnet::compute_layer<input_t, result_t, config2>(layer1_out_flat_relu, logits2, w2, b2);
+    nnet::dense<input_t, result_t, config2>(layer1_out_flat_relu, logits2, w2, b2);
     
     //Softmax
     nnet::softmax<result_t, result_t, softmax_config2>(logits2, res);

--- a/example-prjs/conv-1layer/firmware/myproject.cpp
+++ b/example-prjs/conv-1layer/firmware/myproject.cpp
@@ -22,7 +22,7 @@
 #include "myproject.h"
 
 
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_activation.h"
 

--- a/example-prjs/conv-1layer/firmware/parameters.h
+++ b/example-prjs/conv-1layer/firmware/parameters.h
@@ -4,7 +4,7 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_activation.h"
 #include "nnet_common.h"

--- a/example-prjs/conv-1layer/firmware/parameters.h
+++ b/example-prjs/conv-1layer/firmware/parameters.h
@@ -29,7 +29,7 @@ typedef ap_fixed<32,8> result_t;
 //typedef ap_fixed<18,8> conv1_t;
 
 //hls-fpga-machine-learning insert layer-config
-struct config1 : nnet::conv_config {
+struct config1 : nnet::conv1d_config {
 	static const unsigned pad_left = PAD_LEFT;
 	static const unsigned pad_right = PAD_RIGHT;
 	static const unsigned y_in = Y_INPUTS;
@@ -52,7 +52,7 @@ struct relu_config1 : nnet::activ_config {
     static const unsigned io_type = nnet::io_parallel;
 };
 
-struct config2 : nnet::layer_config {
+struct config2 : nnet::dense_config {
     static const unsigned n_in = Y_OUTPUTS*N_FILT;
     static const unsigned n_out = N_OUTPUTS;
     static const unsigned io_type = nnet::io_parallel;

--- a/example-prjs/conv2d-1layer/firmware/myproject.cpp
+++ b/example-prjs/conv2d-1layer/firmware/myproject.cpp
@@ -78,7 +78,7 @@ void myproject(
     //Dense
     result_t logits2[N_OUTPUTS];
     #pragma HLS ARRAY_PARTITION variable=logits2 complete dim=0
-    nnet::compute_layer<input_t, result_t, config2>(layer1_out_flat_relu, logits2, w2, b2);
+    nnet::dense<input_t, result_t, config2>(layer1_out_flat_relu, logits2, w2, b2);
  
     //Softmax
     nnet::softmax<result_t, result_t, softmax_config2>(logits2, res);

--- a/example-prjs/conv2d-1layer/firmware/myproject.cpp
+++ b/example-prjs/conv2d-1layer/firmware/myproject.cpp
@@ -22,7 +22,7 @@
 #include "myproject.h"
 
 
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_activation.h"

--- a/example-prjs/conv2d-1layer/firmware/parameters.h
+++ b/example-prjs/conv2d-1layer/firmware/parameters.h
@@ -4,7 +4,7 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_activation.h"

--- a/example-prjs/conv2d-1layer/firmware/parameters.h
+++ b/example-prjs/conv2d-1layer/firmware/parameters.h
@@ -70,7 +70,7 @@ struct relu_config1 : nnet::activ_config {
     static const unsigned io_type = nnet::io_parallel;
 };
 
-struct config2 : nnet::layer_config {
+struct config2 : nnet::dense_config {
     static const unsigned n_in = OUT_HEIGHT*OUT_WIDTH*N_FILT;
     static const unsigned n_out = N_OUTPUTS;
     static const unsigned io_type = nnet::io_parallel;

--- a/example-prjs/higgs-1layer/firmware/myproject.cpp
+++ b/example-prjs/higgs-1layer/firmware/myproject.cpp
@@ -55,12 +55,12 @@ void myproject(
     #pragma HLS ARRAY_PARTITION variable=layer1_out complete
     layer1_t logits1[N_LAYER_1];
     #pragma HLS ARRAY_PARTITION variable=logits1 complete
-    nnet::compute_layer<input_t, layer1_t, config1>(data, logits1, w1, b1);
+    nnet::dense<input_t, layer1_t, config1>(data, logits1, w1, b1);
     nnet::relu<layer1_t, layer1_t, relu_config1>(logits1, layer1_out);
 
     result_t logits2[N_OUTPUTS];
     #pragma HLS ARRAY_PARTITION variable=logits2 complete
-    nnet::compute_layer<layer1_t, result_t, config2>(layer1_out, logits2, w2, b2);
+    nnet::dense<layer1_t, result_t, config2>(layer1_out, logits2, w2, b2);
     nnet::sigmoid<result_t, result_t, sigmoid_config2>(logits2, res);
 
 

--- a/example-prjs/higgs-1layer/firmware/myproject.cpp
+++ b/example-prjs/higgs-1layer/firmware/myproject.cpp
@@ -20,7 +20,7 @@
 #include "parameters.h"
 #include "myproject.h"
 
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_activation.h"
 
 //hls-fpga-machine-learning insert weights

--- a/example-prjs/higgs-1layer/firmware/parameters.h
+++ b/example-prjs/higgs-1layer/firmware/parameters.h
@@ -4,7 +4,7 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_activation.h"
 #include "nnet_common.h"
 

--- a/example-prjs/higgs-1layer/firmware/parameters.h
+++ b/example-prjs/higgs-1layer/firmware/parameters.h
@@ -22,7 +22,7 @@ typedef ap_fixed<18,8> result_t;
 typedef ap_fixed<18,8> layer1_t;
 
 //hls-fpga-machine-learning insert layer-config
-struct config1 : nnet::layer_config {
+struct config1 : nnet::dense_config {
         static const unsigned n_in = N_INPUTS;
         static const unsigned n_out = N_LAYER_1;
         static const unsigned io_type = nnet::io_parallel;
@@ -38,7 +38,7 @@ struct relu_config1 : nnet::activ_config {
         static const unsigned table_size = 1024;
         static const unsigned io_type = nnet::io_parallel;
         };
-struct config2 : nnet::layer_config {
+struct config2 : nnet::dense_config {
         static const unsigned n_in = N_LAYER_1;
         static const unsigned n_out = N_OUTPUTS;
         static const unsigned io_type = nnet::io_parallel;

--- a/example-prjs/sublayer/firmware/myproject.cpp
+++ b/example-prjs/sublayer/firmware/myproject.cpp
@@ -21,7 +21,7 @@
 #include "parameters.h"
 #include "myproject.h"
 
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_activation.h"

--- a/example-prjs/sublayer/firmware/myproject.cpp
+++ b/example-prjs/sublayer/firmware/myproject.cpp
@@ -65,38 +65,38 @@ void myproject(
     #pragma HLS ARRAY_PARTITION variable=layer1_out complete dim=0
     layer1_t logits1[N_LAYER_1];
     #pragma HLS ARRAY_PARTITION variable=logits1 complete dim=0
-    nnet::compute_layer<input_t, layer1_t, config1>(data, logits1, w1, b1);
+    nnet::dense<input_t, layer1_t, config1>(data, logits1, w1, b1);
     nnet::relu<layer1_t, layer1_t, relu_config1>(logits1, layer1_out);
 
     layer2_t layer2_out[N_LAYER_2];
     #pragma HLS ARRAY_PARTITION variable=layer2_out complete dim=0
     layer2_t logits2[N_LAYER_2];
     #pragma HLS ARRAY_PARTITION variable=logits2 complete dim=0
-    compute_layer2(layer1_out, logits2);
+    dense2(layer1_out, logits2);
     nnet::relu<layer2_t, layer2_t, relu_config2>(logits2, layer2_out);
 
     layer3_t layer3_out[N_LAYER_3];
     #pragma HLS ARRAY_PARTITION variable=layer3_out complete dim=0
     layer3_t logits3[N_LAYER_3];
     #pragma HLS ARRAY_PARTITION variable=logits3 complete dim=0
-    nnet::compute_layer<layer2_t, layer3_t, config3>(layer2_out, logits3, w3, b3);
+    nnet::dense<layer2_t, layer3_t, config3>(layer2_out, logits3, w3, b3);
     nnet::relu<layer3_t, layer3_t, relu_config3>(logits3, layer3_out);
 
     result_t logits4[N_OUTPUTS];
     #pragma HLS ARRAY_PARTITION variable=logits4 complete dim=0
-    nnet::compute_layer<layer3_t, result_t, config4>(layer3_out, logits4, w4, b4);
+    nnet::dense<layer3_t, result_t, config4>(layer3_out, logits4, w4, b4);
     nnet::softmax<result_t, result_t, softmax_config4>(logits4, res);
 
 
 }
 
-void compute_layer2(layer1_t layer1_out[N_LAYER_1], layer2_t logits2[N_LAYER_2]) {
+void dense2(layer1_t layer1_out[N_LAYER_1], layer2_t logits2[N_LAYER_2]) {
     layer2_t logits2_0[16];
     #pragma HLS ARRAY_PARTITION variable=logits2_0 complete dim=0
     layer2_t logits2_1[16];
     #pragma HLS ARRAY_PARTITION variable=logits2_1 complete dim=0
-    nnet::compute_layer<layer1_t, layer2_t, config2_0>(layer1_out, logits2_0, w2_0, b2_0);
-    nnet::compute_layer<layer1_t, layer2_t, config2_1>(layer1_out, logits2_1, w2_1, b2_1);
+    nnet::dense<layer1_t, layer2_t, config2_0>(layer1_out, logits2_0, w2_0, b2_0);
+    nnet::dense<layer1_t, layer2_t, config2_1>(layer1_out, logits2_1, w2_1, b2_1);
     nnet::merge<layer2_t, 16, 16>(logits2_0, logits2_1, logits2);
 }
 

--- a/example-prjs/sublayer/firmware/myproject.h
+++ b/example-prjs/sublayer/firmware/myproject.h
@@ -34,7 +34,7 @@ void myproject(
       unsigned short &const_size_in,
       unsigned short &const_size_out);
 
-void compute_layer2(layer1_t layer1_out[N_LAYER_1], layer2_t logits2[N_LAYER_2]);
+void dense2(layer1_t layer1_out[N_LAYER_1], layer2_t logits2[N_LAYER_2]);
 
 #endif
 

--- a/example-prjs/sublayer/firmware/parameters.h
+++ b/example-prjs/sublayer/firmware/parameters.h
@@ -4,7 +4,7 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_activation.h"

--- a/example-prjs/sublayer/firmware/parameters.h
+++ b/example-prjs/sublayer/firmware/parameters.h
@@ -28,7 +28,7 @@ typedef ap_fixed<16,6> layer2_t;
 typedef ap_fixed<16,6> layer3_t;
 
 //hls-fpga-machine-learning insert layer-config
-struct config1 : nnet::layer_config {
+struct config1 : nnet::dense_config {
         static const unsigned n_in = N_INPUTS;
         static const unsigned n_out = N_LAYER_1;
         static const unsigned io_type = nnet::io_parallel;
@@ -44,7 +44,7 @@ struct relu_config1 : nnet::activ_config {
         static const unsigned table_size = 1024;
         static const unsigned io_type = nnet::io_parallel;
         };
-struct config2_0 : nnet::layer_config {
+struct config2_0 : nnet::dense_config {
         static const unsigned n_in = N_LAYER_1;
         static const unsigned n_out = 16;
         static const unsigned io_type = nnet::io_parallel;
@@ -55,7 +55,7 @@ struct config2_0 : nnet::layer_config {
         typedef bias_default_t bias_t;
         typedef weight_default_t weight_t;
         };
-struct config2_1 : nnet::layer_config {
+struct config2_1 : nnet::dense_config {
         static const unsigned n_in = N_LAYER_1;
         static const unsigned n_out = 16;
         static const unsigned io_type = nnet::io_parallel;
@@ -71,7 +71,7 @@ struct relu_config2 : nnet::activ_config {
         static const unsigned table_size = 1024;
         static const unsigned io_type = nnet::io_parallel;
         };
-struct config3 : nnet::layer_config {
+struct config3 : nnet::dense_config {
         static const unsigned n_in = N_LAYER_2;
         static const unsigned n_out = N_LAYER_3;
         static const unsigned io_type = nnet::io_parallel;
@@ -87,7 +87,7 @@ struct relu_config3 : nnet::activ_config {
         static const unsigned table_size = 1024;
         static const unsigned io_type = nnet::io_parallel;
         };
-struct config4 : nnet::layer_config {
+struct config4 : nnet::dense_config {
         static const unsigned n_in = N_LAYER_3;
         static const unsigned n_out = N_OUTPUTS;
         static const unsigned io_type = nnet::io_parallel;

--- a/hls-template/firmware/myproject.cpp
+++ b/hls-template/firmware/myproject.cpp
@@ -18,15 +18,7 @@
 //
 #include <iostream>
 
-#include "parameters.h"
 #include "myproject.h"
-
-#include "nnet_dense.h"
-#include "nnet_conv.h"
-#include "nnet_conv2d.h"
-#include "nnet_batchnorm.h"
-#include "nnet_activation.h"
-#include "nnet_pooling.h"
 
 //hls-fpga-machine-learning insert weights
 

--- a/hls-template/firmware/myproject.cpp
+++ b/hls-template/firmware/myproject.cpp
@@ -21,7 +21,7 @@
 #include "parameters.h"
 #include "myproject.h"
 
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_batchnorm.h"

--- a/hls-template/firmware/myproject.cpp
+++ b/hls-template/firmware/myproject.cpp
@@ -31,17 +31,11 @@
 //hls-fpga-machine-learning insert weights
 
 void myproject(
-		  input_t data[N_INPUTS],
-		  result_t res[N_OUTPUTS],
-		  unsigned short &const_size_in,
-		  unsigned short &const_size_out)
-{
+	//hls-fpga-machine-learning insert header
+) {
 
     //hls-fpga-machine-learning insert IO
 
-
-    const_size_in   = N_INPUTS;
-    const_size_out  = N_OUTPUTS;
 
     // ****************************************
     // NETWORK INSTANTIATION

--- a/hls-template/firmware/myproject.h
+++ b/hls-template/firmware/myproject.h
@@ -29,9 +29,7 @@
 
 // Prototype of top level function for C-synthesis
 void myproject(
-      input_t data[N_INPUTS],
-      result_t res[N_OUTPUTS],
-      unsigned short &const_size_in,
-      unsigned short &const_size_out);
+    //hls-fpga-machine-learning insert header
+);
 
 #endif

--- a/hls-template/firmware/parameters.h
+++ b/hls-template/firmware/parameters.h
@@ -11,6 +11,7 @@
 #include "nnet_common.h"
 #include "nnet_batchnorm.h"
 #include "nnet_pooling.h"
+#include "nnet_merge.h"
 
 //hls-fpga-machine-learning insert numbers
 

--- a/hls-template/firmware/parameters.h
+++ b/hls-template/firmware/parameters.h
@@ -4,7 +4,7 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_layer.h"
+#include "nnet_dense.h"
 #include "nnet_conv.h"
 #include "nnet_conv2d.h"
 #include "nnet_activation.h"

--- a/hls-template/myproject_test.cpp
+++ b/hls-template/myproject_test.cpp
@@ -29,18 +29,11 @@
 
 int main(int argc, char **argv)
 {
-
   //hls-fpga-machine-learning insert data
 
+  //hls-fpga-machine-learning insert top-level-function
 
-  result_t res_str[N_OUTPUTS] = {0};
-  unsigned short size_in, size_out;
-  myproject(data_str, res_str, size_in, size_out);
-    
-  for(int i=0; i<N_OUTPUTS; i++){
-    std::cout << res_str[i] << " ";
-  }
-  std::cout << std::endl;
-  
+  //hls-fpga-machine-learning insert output
+
   return 0;
 }

--- a/hls-writer/hls_model.py
+++ b/hls-writer/hls_model.py
@@ -1,0 +1,526 @@
+from __future__ import print_function
+import six
+import numpy as np
+from enum import Enum
+from collections import OrderedDict
+
+from templates import get_config_template, get_function_template
+
+class HLSModel(object):
+    def __init__(self, config, data_reader, layer_list, inputs=None, outputs=None):
+        self.config = config
+        self.reader = data_reader
+
+        # If not provided, assumes layer_list[0] is input, and layer_list[-1] is output
+        self.inputs = inputs if inputs is not None else [layer_list[0]['name']]
+        self.outputs = outputs if outputs is not None else [layer_list[-1]['name']]
+
+        self.index = 0
+        self.graph = OrderedDict()
+        self.output_vars = {}
+
+        self._make_graph(layer_list)
+
+    def _make_graph(self, layer_list):
+        for layer in layer_list:
+            kind = layer['class_name']
+            name = layer['name']
+            inputs = layer.get('inputs', [])
+            outputs = layer.get('outputs', [])
+            if len(inputs) == 0:
+                inputs = [next(reversed(self.graph), 'input')]
+            if len(outputs) == 0:
+                outputs = [name]
+
+            node = layer_map[kind](self, name, layer, inputs, outputs)
+            self.graph[name] = node
+            for o in node.outputs:
+                out_var = node.get_output_variable(output_name=o)
+                if o in self.outputs:
+                    out_var.type = 'result_t'
+                self.output_vars[o] = out_var
+
+    def get_weights_data(self, layer_name, var_name):
+        return self.reader.get_weights_data(layer_name, var_name)
+
+    def quantize_data(self, data, quantize):
+        ones = np.ones_like(data)
+        quant_data = data
+        if quantize == 2:
+            quant_data = np.where(data > 0, ones, -ones)
+        elif quantize == 3:
+            zeros = np.zeros_like(data)
+            quant_data = np.where(data > 0.5, ones, np.where(data <= -0.5, -ones, zeros))
+        return quant_data
+
+    def next_layer(self):
+        self.index += 1
+        return self.index
+
+    def get_config_value(self, key):
+        return self.config[key]
+
+    def get_project_name(self):
+        return self.get_config_value('ProjectName')
+
+    def get_output_dir(self):
+        return self.get_config_value('OutputDir')
+
+    def get_default_precision(self):
+        return self.get_config_value('DefaultPrecision')
+
+    def get_layers(self):
+        return self.graph.values()
+
+    def get_input_variables(self):
+        variables = []
+        for inp in self.inputs:
+            variables.append(self.graph[inp].get_output_variable())
+        return variables
+
+    def get_output_variables(self):
+        variables = []
+        for out in self.outputs:
+            variables.append(self.graph[out].get_output_variable())
+        return variables
+
+    def get_layer_output_variable(self, output_name):
+        return self.output_vars[output_name]
+
+class Variable(object):
+    def __init__(self, var_name, type_name, precision, **kwargs):
+        self.name = var_name.format(**kwargs)
+        self.type = type_name.format(**kwargs)
+        self.precision = precision
+
+class ArrayVariable(Variable):
+    def __init__(self, shape, dim_names, var_name='layer{index}', type_name='layer{index}_t', precision=None, pragma='partition', **kwargs):
+        super(ArrayVariable, self).__init__(var_name, type_name, precision, **kwargs)
+        self.shape = shape
+        self.dim_names = dim_names
+
+        if pragma == 'partition':
+            self.partition()
+        elif pragma == 'reshape':
+            self.reshape()
+        elif pragma == 'stream':
+            self.stream()
+        else:
+            self.pragma = None
+
+    def partition(self, type='complete', factor=None, dim=0):
+        if factor:
+            pragma = '#pragma HLS ARRAY_PARTITION variable={name} {type} factor={factor} dim={dim}'
+        else:
+            pragma = '#pragma HLS ARRAY_PARTITION variable={name} {type} dim={dim}'
+
+        self.pragma = pragma.format(name=self.name, type=type, factor=factor, dim=dim)
+
+    def reshape(self, type='complete', factor=None, dim=0):
+        if factor:
+            pragma = '#pragma HLS ARRAY_RESHAPE variable={name} {type} factor={factor} dim={dim}'
+        else:
+            pragma = '#pragma HLS ARRAY_RESHAPE variable={name} {type} dim={dim}'
+
+        self.pragma = pragma.format(name=self.name, type=type, factor=factor, dim=dim)
+
+    def stream(self, depth=1, dim=1):
+        pragma = '#pragma HLS STREAM variable={name} depth={depth} dim={dim}'
+        self.pragma = pragma.format(name=self.name, depth=depth, dim=dim)
+
+    def get_shape(self):
+        return zip(self.dim_names, self.shape)
+
+    def definition_cpp(self):
+        array_shape = '*'.join([str(k) for k in self.dim_names])
+        return '{type} {name}[{shape}]'.format(type=self.type, name=self.name, shape=array_shape)
+
+    def size(self):
+        nelem = 1
+        for dim in self.shape:
+            nelem *= dim
+        return nelem
+
+    def size_cpp(self):
+        return '*'.join([str(k) for k in self.dim_names])
+
+class WeightVariable(Variable):
+    def __init__(self, var_name, type_name, precision, data=None, **kwargs):
+        super(WeightVariable, self).__init__(var_name, type_name, precision, **kwargs)
+        self.data = data
+        self.nzeros = -1
+        self.shape = None
+        if self.data is not None:
+            self.shape = list(self.data.shape)
+            self.nzeros = 0
+            for x in np.nditer(self.data, order='C'):
+                if x == 0:
+                    self.nzeros += 1
+
+class Layer(object):
+    def __init__(self, model, name, attributes, inputs, outputs=None):
+        self.model = model
+        self.name = name
+        self.index = model.next_layer()
+        self.inputs = inputs
+        self.outputs = outputs
+        if self.outputs is None:
+            self.outputs = [self.name]
+
+        self.attributes = attributes
+        self._function_template = get_function_template(self.__class__.__name__)
+        self._config_template = get_config_template(self.__class__.__name__)
+        self.weights = OrderedDict()
+        self.variables = OrderedDict()
+
+        self.initialize()
+
+    def initialize(self):
+        raise NotImplementedError
+
+    def set_attr(self, key, value):
+        self.attributes[key] = value
+
+    def get_attr(self, key, default=None):
+        return self.attributes.get(key, default)
+
+    def get_input_variable(self, input_name=None):
+        if input_name is not None:
+            return self.model.get_layer_output_variable(input_name)
+        else:
+            return self.model.get_layer_output_variable(self.inputs[0])
+
+    def get_output_variable(self, output_name=None):
+        if output_name is not None:
+            return self.variables[output_name]
+        else:
+            return next(iter(self.variables.values()))
+
+    def get_weights(self, var_name=None):
+        if var_name:
+            return self.weights[var_name]
+
+        return self.weights.values()
+
+    def get_variables(self):
+        return self.variables.values()
+
+    def add_output_variable(self, shape, dim_names, out_name=None, var_name='layer{index}_out', type_name='layer{index}_t', precision=None, pragma='auto'):
+        if out_name is None:
+            out_name = self.outputs[0]
+
+        if precision is None:
+            precision = self.model.get_default_precision()
+
+        if pragma == 'auto':
+            if self.model.get_config_value('IOType') == 'io_serial':
+                pragma = 'stream'
+            else:
+                if self.name in self.model.inputs:
+                    pragma = 'reshape'
+                else:
+                    pragma = 'partition'
+
+        out = ArrayVariable(shape, dim_names, var_name=var_name, type_name=type_name, precision=precision, pragma=pragma, index=self.index)
+
+        self.variables[out_name] = out
+
+    def add_weights(self, quantize=0):
+        data = self.model.get_weights_data(self.name, 'kernel')
+
+        self.add_weights_variable(name='weight', var_name='w{index}', type_name='weight_default_t', data=data, quantize=quantize)
+
+    def add_bias(self, quantize=0):
+        data = self.model.get_weights_data(self.name, 'bias')
+        if data is None:
+            data = np.zeros(self.get_output_variable().shape[-1])
+            quantize = 0 # Don't quantize non-existant bias
+
+        self.add_weights_variable(name='bias', var_name='b{index}', type_name='bias_default_t', data=data, quantize=quantize)
+
+    def add_weights_variable(self, name, var_name=None, type_name='weight_default_t', precision=None, data=None, quantize=0):
+        if var_name is None:
+            var_name = name + '{index}'
+
+        if precision is None:
+            precision = self.model.get_default_precision()
+
+        if data is None:
+            data = self.model.get_weights_data(self.name, name)
+        elif isinstance(data, six.string_types):
+            data = self.model.get_weights_data(self.name, data)
+
+        if quantize > 0:
+            data = self.model.quantize_data(data, quantize)
+
+        var = WeightVariable(var_name, type_name=type_name, precision=precision, data=data, index=self.index)
+
+        self.weights[name] = var
+
+    def _default_function_params(self):
+        params = {}
+        params['config'] = 'config{}'.format(self.index)
+        params['input_t'] = self.get_input_variable().type
+        params['output_t'] = self.get_output_variable().type
+        params['input'] = self.get_input_variable().name
+        params['output'] = self.get_output_variable().name
+
+        return params
+
+    def _default_config_params(self):
+        params = {}
+        params.update(self.attributes)
+        params['index'] = self.index
+        params['iotype'] = self.model.get_config_value('IOType')
+        params['reuse'] = self.model.get_config_value('ReuseFactor')
+
+        return params
+
+    # myproject.cpp/h
+    def function_cpp(self):
+        raise NotImplementedError
+
+    # parameters.h
+    def config_cpp(self):
+        raise NotImplementedError
+
+    def get_numbers_cpp(self):
+        numbers = ''
+        for k, v in self.get_output_variable().get_shape():
+            numbers += '#define {} {}\n'.format(k,v)
+
+        return numbers
+
+    def precision_cpp(self):
+        return 'typedef {precision} layer{index}_t;'.format(precision=self.get_output_variable().precision, index=self.index)
+
+class Input(Layer):
+    def initialize(self):
+        shape = self.attributes['input_shape']
+        if shape[0] is None:
+            shape = shape[1:]
+        dims = ['N_INPUT{}_{}'.format(self.index, i) for i in range(1, len(shape) + 1)]
+        self.add_output_variable(shape, dims, var_name=self.name, type_name='input_t')
+
+    def function_cpp(self):
+        return None
+
+    def config_cpp(self):
+        return None
+
+class Dense(Layer):
+    def initialize(self):
+        shape = [self.attributes['n_out']]
+        dims = ['N_LAYER_{}'.format(self.index)]
+        quantize = self.get_attr('quantize')
+        self.add_output_variable(shape, dims)
+        self.add_weights(quantize=quantize)
+        self.add_bias(quantize=quantize)
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['w'] = self.get_weights('weight').name
+        params['b'] = self.get_weights('bias').name
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['n_in'] = self.get_input_variable().size_cpp()
+        params['n_out'] = self.get_output_variable().size_cpp()
+        params['nzeros'] = self.get_weights('weight').nzeros
+
+        return self._config_template.format(**params)
+
+class Conv1D(Layer):
+    def initialize(self):
+        shape = [self.attributes['y_out'], self.attributes['n_filt']]
+        dims = ['Y_OUTPUTS_{}'.format(self.index), 'N_FILT_{}'.format(self.index)]
+        self.add_output_variable(shape, dims)
+        self.add_weights()
+        self.add_bias()
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['w'] = self.get_weights('weight').name
+        params['b'] = self.get_weights('bias').name
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['y_in'] = self.get_input_variable().dim_names[0]
+        params['n_chan'] = self.get_input_variable().dim_names[1]
+        params['n_filt'] = 'N_FILT_{}'.format(self.index)
+        params['y_out'] = 'Y_OUTPUTS_{}'.format(self.index)
+        params['nzeros'] = self.get_weights('weight').nzeros
+
+        return self._config_template.format(**params)
+
+class Conv2D(Layer):
+    def initialize(self):
+        shape = [self.attributes['out_height'], self.attributes['out_width'], self.attributes['n_filt']]
+        dims = ['OUT_HEIGHT_{}'.format(self.index), 'OUT_WIDTH_{}'.format(self.index), 'N_FILT_{}'.format(self.index)]
+        self.add_output_variable(shape, dims)
+        self.add_weights()
+        self.add_bias()
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['w'] = self.get_weights('weight').name
+        params['b'] = self.get_weights('bias').name
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['in_height'] = self.get_input_variable().dim_names[0]
+        params['in_width'] = self.get_input_variable().dim_names[1]
+        params['n_chan'] = self.get_input_variable().dim_names[2]
+        params['out_height'] = self.get_output_variable().dim_names[0]
+        params['out_width'] = self.get_output_variable().dim_names[1]
+        params['n_filt'] = self.get_output_variable().dim_names[2]
+        params['nzeros'] = self.get_weights('weight').nzeros
+
+        return self._config_template.format(**params)
+
+class Pooling1D(Layer):
+    def initialize(self):
+        shape = [self.attributes['y_out'], self.attributes['n_filt']] #TODO complete this
+        dims = ['Y_OUTPUTS_{}'.format(self.index), 'N_FILT_{}'.format(self.index)]
+        self.add_output_variable(shape, dims)
+        self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0])
+
+    def function_cpp(self):
+        params = self._default_function_params()
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['n_in'] = self.get_input_variable().size_cpp()
+        params['n_out'] = self.get_output_variable().size_cpp()
+
+        return self._config_template.format(**params)
+
+class Pooling2D(Layer):
+    def initialize(self):
+        shape = [self.attributes['out_height'], self.attributes['out_width'], self.attributes['n_filt']]
+        dims = ['OUT_HEIGHT_{}'.format(self.index), 'OUT_WIDTH_{}'.format(self.index), 'N_FILT_{}'.format(self.index)]
+        self.add_output_variable(shape, dims)
+        self.set_attr('pool_op', self.get_attr('class_name').split('Pooling')[0])
+
+    def function_cpp(self):
+        params = self._default_function_params()
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['n_in'] = self.get_input_variable().dim_names[0]
+        params['in_width'] = self.get_input_variable().dim_names[1]
+        params['out_height'] = self.get_output_variable().dim_names[0]
+        params['out_width'] = self.get_output_variable().dim_names[1]
+        params['n_filt'] = self.get_output_variable().dim_names[2]
+
+        return self._config_template.format(**params)
+
+class Activation(Layer):
+    def initialize(self):
+        inp = self.get_input_variable()
+        shape = inp.shape
+        dims = inp.dim_names
+        self.add_output_variable(shape, dims)
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['activation'] = self.get_attr('activation')
+        params['config'] = '{}_config{}'.format(self.get_attr('activation'), self.index)
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['type'] = self.get_attr('activation')
+        params['n_in'] = self.get_input_variable().size_cpp()
+
+        return self._config_template.format(**params)
+
+class ParametrizedActivation(Activation):
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['activation'] = self._get_act_function_name()
+        params['param'] = self.get_attr('activ_param', 1.0)
+        params['config'] = '{}_config{}'.format(self.get_attr('activation'), self.index)
+
+        return [self._function_template.format(**params)]
+
+    def _get_act_function_name(self):
+        act = self.get_attr('activation').lower()
+        if act == 'leakyrelu':
+            return 'leaky_relu'
+        elif act == 'thresholdedrelu':
+            return 'thresholded_relu'
+        else:
+            return act # ELU activation
+
+class PReLU(Activation):
+    def initialize(self):
+        super(PReLU, self).initialize()
+        self.add_weights_variable(name='alpha', var_name='a{index}')
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['activation'] = self.get_attr('activation').lower()
+        params['param'] = self.get_weights('alpha').name
+        params['config'] = '{}_config{}'.format(self.get_attr('activation'), self.index)
+
+        return [self._function_template.format(**params)]
+
+class BatchNormalization(Layer):
+    def initialize(self):
+        inp = self.get_input_variable()
+        shape = inp.shape
+        dims = inp.dim_names
+        self.add_output_variable(shape, dims)
+
+        var = self.model.get_weights_data(self.name, 'moving_variance')
+        gamma = self.model.get_weights_data(self.name, 'gamma')
+        scale_data = gamma / np.sqrt(var + self.get_attr('epsilon'))
+
+        self.add_weights_variable(name='scale', data=scale_data)
+        self.add_weights_variable(name='beta', data='beta')
+        self.add_weights_variable(name='mean', data='moving_mean')
+
+    def function_cpp(self):
+        params = self._default_function_params()
+        params['scale'] = self.get_weights('scale').name
+        params['beta'] = self.get_weights('beta').name
+        params['mean'] = self.get_weights('mean').name
+
+        return [self._function_template.format(**params)]
+
+    def config_cpp(self):
+        params = self._default_config_params()
+        params['n_in'] = self.get_input_variable().size_cpp()
+
+        return self._config_template.format(**params)
+
+layer_map = {
+    'InputLayer'         : Input,
+    'Activation'         : Activation,
+    'LeakyReLU'          : ParametrizedActivation,
+    'ThresholdedReLU'    : ParametrizedActivation,
+    'ELU'                : ParametrizedActivation,
+    'PReLU'              : PReLU,
+    'Dense'              : Dense,
+    'BinaryDense'        : Dense,
+    'TernaryDense'       : Dense,
+    'Conv1D'             : Conv1D,
+    'Conv2D'             : Conv2D,
+    'BatchNormalization' : BatchNormalization,
+    'MaxPooling1D'       : Pooling1D,
+    'AveragePooling1D'   : Pooling1D,
+    'MaxPooling2D'       : Pooling2D,
+    'AveragePooling2D'   : Pooling2D,
+}

--- a/hls-writer/hls_writer.py
+++ b/hls-writer/hls_writer.py
@@ -5,909 +5,7 @@ from shutil import copyfile
 import numpy as np
 import os
 import re
-
-def hls_writer(layer_list, yamlConfig):
-
-    filedir = os.path.dirname(os.path.abspath(__file__))
-
-    ###################
-    ## myproject.cpp
-    ###################
-
-    f = open(os.path.join(filedir,'../hls-template/firmware/myproject.cpp'),'r')
-    fout = open('{}/firmware/{}.cpp'.format(yamlConfig['OutputDir'], yamlConfig['ProjectName']),'w')
-
-    # Set some variables to make the routine after a bit smoother
-    do_batchnorm = False
-    is_dense = False
-    is_conv2d = False
-    for i in range(1,len(layer_list)+1):
-     if layer_list[i-1]['class_name'] == 'BatchNormalization': do_batchnorm = True
-    for i in range(1,len(layer_list)+1):
-     if layer_list[i-1]['class_name']=='Conv2D':
-      is_conv2d = True
-      break
-    if not is_conv2d:
-     for i in range(1,len(layer_list)+1):
-      if layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense':
-       is_dense = True
-       break
-    
-    activation_layers = ['Activation', 'LeakyReLU', 'ThresholdedReLU', 'ELU', 'PReLU']
-    
-    # lines to add to .cpp for sublayers
-    sublayerlines = []
-    # lines to add to .h for sublayers
-    sublayerlines_h = []
-    for line in f.readlines():
-        #Add headers to weights and biases
-        if 'myproject' in line:
-            newline = line.replace('myproject',yamlConfig['ProjectName'])
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='Conv1D':
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[Y_INPUTS_1][N_CHAN_1]')
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='Conv2D':
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[IN_HEIGHT_1][IN_WIDTH_1][N_CHAN_1]')
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='BatchNormalization' and is_conv2d:
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[IN_HEIGHT_1][IN_WIDTH_1][N_FILT_1]')
-        elif 'const_size_in   = N_INPUTS' in line and layer_list[0]['class_name']=='Conv1D':
-            newline = line.replace('const_size_in   = N_INPUTS','const_size_in   = Y_INPUTS_1*N_CHAN_1')
-        elif 'const_size_in   = N_INPUTS' in line and layer_list[0]['class_name']=='Conv2D':
-            newline = line.replace('const_size_in   = N_INPUTS','const_size_in   = IN_HEIGHT_1*IN_WIDTH_1*N_CHAN_1')
-        elif 'const_size_in   = N_INPUTS' in line and layer_list[0]['class_name']=='BatchNormalization' and is_conv2d:
-            newline = line.replace('const_size_in   = N_INPUTS','const_size_in   = IN_HEIGHT_1*IN_WIDTH_1*N_FILT_1')
-        elif '//hls-fpga-machine-learning insert weights' in line:
-            newline = line
-            for i in range(1,len(layer_list)+1):
-                if layer_list[i-1]['class_name'] == 'BatchNormalization':
-                    newline += '#include "weights/beta{}.h"\n'.format(i)
-                    newline += '#include "weights/scale{}.h"\n'.format(i)
-                    newline += '#include "weights/mean{}.h"\n'.format(i)
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    pass # No weights for pooling
-                else:
-                    if layer_list[i-1]['n_part']>1:
-                        for i_part in range(layer_list[i-1]['n_part']):
-                            newline += '#include "weights/w{}_{}.h"\n'.format(i,i_part)
-                            newline += '#include "weights/b{}_{}.h"\n'.format(i,i_part)
-                    elif layer_list[i-1]['class_name'] not in activation_layers:
-                        newline += '#include "weights/w{}.h"\n'.format(i)
-                        newline += '#include "weights/b{}.h"\n'.format(i)
-                        if layer_list[i-1].get('activation') == 'PReLU':
-                            newline += '#include "weights/a{}.h"\n'.format(i)
-                    elif layer_list[i-1]['class_name'] == 'PReLU':
-                        newline += '#include "weights/a{}.h"\n'.format(i)
-
-        #Add input/output type
-        elif '//hls-fpga-machine-learning insert IO' in line:
-            newline = line
-            if yamlConfig["IOType"] == "io_parallel":
-                newline += '    #pragma HLS ARRAY_RESHAPE variable=data complete dim=0 \n'
-                newline += '    #pragma HLS ARRAY_RESHAPE variable=res complete dim=0 \n'
-                newline += '    #pragma HLS INTERFACE ap_vld port=data,res \n'
-                newline += '    #pragma HLS PIPELINE \n'
-            if yamlConfig["IOType"] == "io_serial":
-                newline += '    #pragma HLS INTERFACE axis port=data,res \n'
-                newline += '    #pragma HLS DATAFLOW \n'
-
-        #Add layers
-        elif '//hls-fpga-machine-learning insert layers' in line:
-            newline = line + '\n'
-            for i in range(1,len(layer_list)+1):
-                
-                #Input to compute_layer
-
-                #First layer and dense
-                if i==1 and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or (layer_list[i-1]['class_name']=='BatchNormalization' and is_dense)):
-                    input_type = 'input_t'
-                    input_object = 'data'
-                    n_in = 'N_INPUTS'
-                #Layer is Dense and previous layer was Conv1D
-                elif layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv1D':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    n_in = 'Y_OUTPUTS_{}*N_FILT_{}'.format(i-1,i-1)
-                #Layer is Dense and previous layer was Conv2D
-                elif layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv2D':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    n_in = 'IN_HEIGHT_{}*IN_WIDTH_{}*N_FILT_{}'.format(i-1,i-1,i-1)
-                #Layer is Dense, BatchNormalization or Activation
-                elif layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or layer_list[i-1]['class_name'] in activation_layers:
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    n_in = 'N_LAYER_{}'.format(i-1)
-                elif is_dense and layer_list[i-1]['class_name']=='BatchNormalization':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    n_in = 'N_LAYER_{}'.format(i-1)
-                    n_filt = 'N_FILT_{}'.format(i-1)
-                elif (i==1 and layer_list[i-1]['class_name']=='BatchNormalization' and is_conv2d):
-                    input_type = 'input_t'
-                    input_object = 'data'
-                    in_height = 'IN_HEIGHT_{}'.format(i)
-                    in_width = 'IN_WIDTH_{}'.format(i)
-                    n_chan = 'N_FILT_{}'.format(i)
-                elif is_conv2d and layer_list[i-1]['class_name']=='BatchNormalization':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    n_in = 'OUT_HEIGHT_{}*OUT_WIDTH_{}*N_FILT_{}'.format(i-1,i-1,i-1)
-                    n_filt = 'N_FILT_{}'.format(i-1)
-                #First layer and Conv1D
-                elif (i==1 and layer_list[i-1]['class_name']=='Conv1D'):
-                    input_type = 'input_t'
-                    input_object = 'data'
-                    y_in = 'Y_INPUTS_{}'.format(i)
-                    n_chan = 'N_CHAN_{}'.format(i)
-                #Layer is Conv1D
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    y_in = 'Y_INPUTS_{}'.format(i)
-                    n_chan = 'N_CHAN_{}'.format(i)
-                #First layer and Conv2D
-                elif (i==1 and layer_list[i-1]['class_name']=='Conv2D'):
-                    input_type = 'input_t'
-                    input_object = 'data'
-                    in_height = 'IN_HEIGHT_{}'.format(i)
-                    in_width = 'IN_WIDTH_{}'.format(i)
-                    n_chan = 'N_CHAN_{}'.format(i)
-                #Layer is Conv2D
-                elif layer_list[i-1]['class_name']=='Conv2D':
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    in_height = 'IN_HEIGHT_{}'.format(i)
-                    in_width = 'IN_WIDTH_{}'.format(i)
-                    n_chan = 'N_CHAN_{}'.format(i)
-                #Pooling layer
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    input_type = 'layer{}_t'.format(i-1)
-                    input_object = 'layer{}_out'.format(i-1)
-                    output_object = 'layer{}_out'.format(i)
-                    in_height = 'IN_HEIGHT_{}'.format(i)
-                    in_width = 'IN_WIDTH_{}'.format(i)
-                    out_height = 'OUT_HEIGHT_{}'.format(i)
-                    out_width = 'OUT_WIDTH_{}'.format(i)
-                    n_filt = 'N_FILT_{}'.format(i)
-                #Currently doesn't allow all combinations
-
-
-                #Outputs of compute_layer and activation 
-                if i==len(layer_list) and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense'):
-                    output_type = 'result_t'
-                    output_object = 'res'
-                    n_out = 'N_OUTPUTS'
-                    if layer_list[i-1]['class_name'] in activation_layers: input_type = 'result_t'
-                elif i==len(layer_list) and layer_list[i-1]['class_name'] in activation_layers and is_dense:
-                    output_type = 'result_t'
-                    output_object = 'res'
-                    n_out = 'N_OUTPUTS'
-                    input_type = 'result_t'
-                elif i==len(layer_list) and is_dense and layer_list[i-1]['class_name']=='BatchNormalization':
-                    output_type = 'result_t'
-                    output_object = 'res'
-                    n_out = 'N_OUTPUTS'
-                elif i==len(layer_list) and is_conv2d and layer_list[i-1]['class_name']=='BatchNormalization':
-                    output_type = 'layer{}_t'.format(i)
-                    output_object = 'layer{}_out'.format(i)
-                    out_height = 'OUT_HEIGHT_{}'.format(i)
-                    out_width = 'OUT_WIDTH_{}'.format(i)
-                    n_filt = 'N_FILT_{}'.format(i)
-                elif(i==len(layer_list)-1 and is_dense and layer_list[i-1]['class_name']=='BatchNormalization' and layer_list[i]['class_name'] in activation_layers):
-                    output_type = 'result_t'
-                    output_object = 'layer{}_out'.format(i)
-                    n_out = 'N_OUTPUTS' 
-                elif layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or (layer_list[i-1]['class_name']=='BatchNormalization' and is_dense) or (layer_list[i-1]['class_name'] in activation_layers and is_dense):
-                    output_type = 'layer{}_t'.format(i)
-                    output_object = 'layer{}_out'.format(i)
-                    n_out = 'N_LAYER_{}'.format(i)
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    output_type = 'layer{}_t'.format(i)
-                    output_object = 'layer{}_out'.format(i)
-                    y_out = 'Y_OUTPUTS_{}'.format(i)
-                    n_filt = 'N_FILT_{}'.format(i)
-                elif layer_list[i-1]['class_name']=='Conv2D' or (is_conv2d and layer_list[i-1]['class_name']=='BatchNormalization'):
-                    output_type = 'layer{}_t'.format(i)
-                    output_object = 'layer{}_out'.format(i)
-                    out_height = 'OUT_HEIGHT_{}'.format(i)
-                    out_width = 'OUT_WIDTH_{}'.format(i)
-                    n_filt = 'N_FILT_{}'.format(i)
-                #Currently assumes end with dense
-
-                if( i!=len(layer_list) ):
-                    if layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or (layer_list[i-1]['class_name']=='BatchNormalization' and is_dense) or (layer_list[i-1]['class_name'] in activation_layers and is_dense):
-                        newline += '    {} layer{}_out[{}];\n'.format(output_type,i,n_out)
-                    elif layer_list[i-1]['class_name']=='Conv1D' or 'Pooling1D' in layer_list[i-1]['class_name']:
-                        newline += '    {} layer{}_out[{}*{}];\n'.format(output_type,i,y_out,n_filt)
-                    elif layer_list[i-1]['class_name']=='Conv2D' or 'Pooling2D' in layer_list[i-1]['class_name']:
-                        newline += '    {} layer{}_out[{}*{}*{}];\n'.format(output_type,i,out_height,out_width,n_filt)
-                    elif layer_list[i-1]['class_name']=='BatchNormalization' and is_conv2d:
-                        if i!= 1: newline += '    {} layer{}_out[{}*{}*{}];\n'.format(output_type,i,out_height,out_width,n_filt)
-                        else: newline += '    {} layer{}_out[{}*{}*{}];\n'.format(output_type,i,in_height,in_width,n_filt)
-                    if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=layer{}_out complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=layer{}_out depth=1\n'.format(i)
-
-                #github Issue 53
-                #Compute Dense layer
-                #if layer_list[i-1]['activation'] == "linear" and layer_list[i-1]['class_name']=='Dense':
-                #    newline += '    nnet::compute_layer<{}, {}, config{}>({}, {}, w{}, b{});\n'.format(input_type, output_type, i, input_object, output_object, i, i)
-                #elif layer_list[i-1]['class_name']=='Dense':
-                if layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense':
-                    newline += '    {} logits{}[{}];\n'.format(output_type,i,n_out)
-                    if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} depth=1\n'.format(i)
-                    
-                    if layer_list[i-1]['n_part']==1 or yamlConfig["IOType"]=="io_serial":
-                        # Use one layer if there's only 1 partition, or if we're using serial mode
-                        newline += '    nnet::compute_layer<{}, {}, config{}>({}, logits{}, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
-                    else:
-                        # initialize arrays for sublayer outputs
-                        newline += '    compute_layer{}({}, logits{});\n'.format(i, input_object, i)
-                        sublayerline = 'void compute_layer{}({} {}[{}], {} logits{}[{}]) {{\n'.format(i,input_type, input_object, n_in, output_type, i, n_out)
-                        sublayerline_h = 'void compute_layer{}({} {}[{}], {} logits{}[{}]);\n'.format(i,input_type, input_object, n_in, output_type, i, n_out)
-                        sublayerlines_h.append(sublayerline_h)
-                        for i_part in range(0, layer_list[i-1]['n_part']):
-                            n_subout = layer_list[i-1]['n_subout'][i_part]
-                            sublayerline += '    {} logits{}_{}[{}];\n'.format(output_type,i,i_part,n_subout)                        
-                            if yamlConfig["IOType"] == "io_parallel": sublayerline += '    #pragma HLS ARRAY_PARTITION variable=logits{}_{} complete dim=0\n'.format(i,i_part)
-                            if yamlConfig["IOType"] == "io_serial":   sublayerline += '    #pragma HLS STREAM variable=logits{}_{} depth=1\n'.format(i,i_part)
-
-                        # initialize arrays for merged partial outputs 
-                        for i_part in range(1, layer_list[i-1]['n_part']-1):
-                            n_mergeout = sum([layer_list[i-1]['n_subout'][kk] for kk in range(0, i_part+1)])
-                            sublayerline += '    {} logits{}_0to{}[{}];\n'.format(output_type,i,i_part,n_mergeout)                        
-                            if yamlConfig["IOType"] == "io_parallel": sublayerline += '    #pragma HLS ARRAY_PARTITION variable=logits{}_0to{} complete dim=0\n'.format(i,i_part)
-                            if yamlConfig["IOType"] == "io_serial":   sublayerline += '    #pragma HLS STREAM variable=logits{}_0to{} depth=1\n'.format(i,i_part)
-                        # compute sublayer outputs
-                        for i_part in range(0, layer_list[i-1]['n_part']):
-                            sublayerline += '    nnet::compute_layer<{}, {}, config{}_{}>({}, logits{}_{}, w{}_{}, b{}_{});\n'.format(input_type, output_type, i, i_part, input_object, i, i_part, i, i_part, i, i_part)   
-
-                        # merge sublayer outputs
-                        for i_part in range(0, layer_list[i-1]['n_part']-1):
-                            n_subout = layer_list[i-1]['n_subout'][i_part+1]
-                            n_mergeout = sum([layer_list[i-1]['n_subout'][kk] for kk in range(0, i_part+1)])
-                            if layer_list[i-1]['n_part']==2:
-                                sublayerline += '    nnet::merge<{}, {}, {}>(logits{}_{}, logits{}_{}, logits{});\n'.format(output_type, n_mergeout, n_subout, i, i_part, i, i_part+1, i)
-                            elif i_part==0: 
-                                sublayerline += '    nnet::merge<{}, {}, {}>(logits{}_{}, logits{}_{}, logits{}_0to{});\n'.format(output_type, n_mergeout, n_subout, i, i_part, i, i_part+1, i, i_part+1)
-                            elif i_part==layer_list[i-1]['n_part']-2:
-                                sublayerline += '    nnet::merge<{}, {}, {}>(logits{}_0to{}, logits{}_{}, logits{});\n'.format(output_type, n_mergeout, n_subout, i, i_part, i, i_part+1, i)
-                            else:
-                                sublayerline += '    nnet::merge<{}, {}, {}>(logits{}_0to{}, logits{}_{}, logits{}_0to{});\n'.format(output_type, n_mergeout, n_subout, i, i_part, i, i_part+1, i, i_part+1)
-                        sublayerline += '}\n'
-                        sublayerlines.append(sublayerline)
-                    
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    if i>1 and layer_list[i-2]['class_name']=='Conv1D':
-                        newline += '    {} conv_layer{}_in[{}][{}];\n'.format(input_type,i,y_in,n_chan)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_in complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_in depth=1\n'.format(i)
-                        newline += '    nnet::unflatten<{}, {}, {}>({}, conv_layer{}_in);\n'.format(input_type, y_in, n_chan, input_object, i)                              
-                        newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_1d<{}, {}, config{}>(conv_layer{}_in, conv_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, i, i, i, i, i)  
-                    else:                        
-                        newline += '    {} conv_layer{}_out[{}][{}];\n'.format(output_type,i,y_out,n_filt)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_1d<{}, {}, config{}>({}, conv_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
-                    newline += '    {} logits{}[{}*{}];\n'.format(output_type,i,y_out,n_filt)
-                    if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
-                    newline += '    nnet::flatten<{}, {}, {}>(conv_layer{}_out, logits{});\n'.format(input_type, y_out, n_filt, i, i)
-                elif layer_list[i-1]['class_name']=='Conv2D':
-                    if i>1 and (layer_list[i-2]['class_name']=='Conv2D' or layer_list[i-2]['class_name']=='BatchNormalization'):
-                        newline += '    {} conv2d_layer{}_in[{}][{}][{}];\n'.format(input_type,i,in_height,in_width,n_chan)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv2d_layer{}_in complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv2d_layer{}_in depth=1\n'.format(i)
-                        newline += '    nnet::unflatten<{}, {}, {}, {}>({}, conv2d_layer{}_in);\n'.format(input_type, in_height, in_width, n_chan, input_object, i)                              
-                        newline += '    {} conv2d_layer{}_out[{}][{}][{}];\n'.format(output_type,i,out_height,out_width,n_filt)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv2d_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv2d_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_2d<{}, {}, config{}>(conv2d_layer{}_in, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, i, i, i, i, i)  
-                    else:                        
-                        newline += '    {} conv2d_layer{}_out[{}][{}][{}];\n'.format(output_type,i,out_height,out_width,n_filt)
-                        if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=conv2d_layer{}_out complete dim=0\n'.format(i)
-                        if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=conv2d_layer{}_out depth=1\n'.format(i)
-                        newline += '    nnet::conv_2d<{}, {}, config{}>({}, conv2d_layer{}_out, w{}, b{});\n'.format(input_type, output_type, i, input_object, i, i, i, i)
-                    newline += '    {} logits{}[{}*{}*{}];\n'.format(output_type,i,out_height,out_width,n_filt)
-                    if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
-                    newline += '    nnet::flatten<{}, {}, {}, {}>(conv2d_layer{}_out, logits{});\n'.format(output_type, out_height, out_width, n_filt, i, i)
-                elif layer_list[i-1]['class_name'] == 'BatchNormalization' and is_dense:
-                    newline += '    nnet::normalize<{}, {}, config{}>({}, {}, scale{}, beta{}, mean{});\n'.format(input_type, output_type, i, input_object, output_object, i, i, i)
-                elif i==1 and layer_list[i-1]['class_name'] == 'BatchNormalization' and is_conv2d:
-                    newline += '    {} logits{}[{}*{}*{}];\n'.format(output_type,i,in_height,in_width,n_filt)
-                    if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=logits{} complete dim=0\n'.format(i)
-                    if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=logits{} complete depth=1\n'.format(i)
-                    newline += '    nnet::flatten<{}, {}, {}, {}>({}, logits{});\n'.format(input_type, in_height, in_width, n_filt, input_object, i)
-                    newline += '    nnet::normalize<{}, {}, config{}>(logits{}, {}, scale{}, beta{}, mean{});\n'.format(output_type, output_type, i, i, output_object, i, i, i)
-                elif layer_list[i-1]['class_name'] == 'BatchNormalization' and is_conv2d:
-                    newline += '    nnet::normalize<{}, {}, config{}>({}, {}, scale{}, beta{}, mean{});\n'.format(input_type, output_type, i, input_object, output_object, i, i, i)
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    info = layer_list[i-1]['class_name'].split('Pooling')
-                    d = int(info[1].split('D')[0]) # n dimensions
-                    if d == 1:
-                        newline += '    nnet::pooling1d<{}, config{}>({}, {});\n'.format(input_type, i, input_object, output_object)
-                    elif d == 2:
-                        # Unflatten if needed: if the last layer is activation or batchnorm
-                        unflatten = layer_list[i-2]['class_name'] in activation_layers
-                        unflatten |= 'activation' in layer_list[i-2].keys()
-                        unflatten |= layer_list[i-2]['class_name'] == 'BatchNormalization'
-                        if unflatten:
-                            # Add the unflatten layer
-                            inshape = ''.join('[{0}]'.format(dim) for dim in [in_height, in_width, n_filt])
-                            newline += '    {} pool2d_layer{}_in{};\n'.format(input_type, i, inshape)
-                            if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=pool2d_layer{}_in complete dim=0\n'.format(i)
-                            if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=pool2d_layer{}_in depth=1\n'.format(i)
-                            newline += '    nnet::unflatten<{}, {}, {}, {}>({}, pool2d_layer{}_in);\n'.format(input_type, in_height, in_width, n_filt, input_object, i)                              
-                            outshape = ''.join('[{0}]'.format(dim) for dim in [out_height, out_width, n_filt])
-                            newline += '    {} pool2d_layer{}_out{};\n'.format(input_type, i, outshape)
-                            if yamlConfig["IOType"] == "io_parallel": newline += '    #pragma HLS ARRAY_PARTITION variable=pool2d_layer{}_out complete dim=0\n'.format(i)
-                            if yamlConfig["IOType"] == "io_serial":   newline += '    #pragma HLS STREAM variable=pool2d_layer{}_out depth=1\n'.format(i)
-                            # Do the pooling layer
-                            newline += '    nnet::pooling2d<{}, config{i}>(pool2d_layer{i}_in, pool2d_layer{i}_out);\n'.format(input_type, i=i)
-                        else:
-                            newline += '    nnet::pooling2d<{}, config{i}>({}, {});\n'.format(input_type, i, input_object, output_object)
-                        # Flatten the pooling output
-                        newline += '    nnet::flatten<{}, {}, {}, {}>(pool2d_layer{}_out, layer{}_out);\n'.format(input_type, out_height, out_width, n_filt, i, i)
-                        
-                #Activations
-                if layer_list[i-1]['class_name'] in activation_layers or 'activation' in layer_list[i-1].keys():
-                    if layer_list[i-1]['class_name'] not in activation_layers:
-                        act_input_type = output_type
-                        act_input_object = "logits" + str(i)
-                    else:
-                        act_input_type = input_type
-                        act_input_object = input_object
-                    
-                    activation_name = layer_list[i-1]['activation']+'_config'+str(i)
-                    activation_param = layer_list[i-1].get('activ_param')
-                    if layer_list[i-1]['activation'] == "relu":
-                        newline += '    nnet::relu<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "LeakyReLU":
-                        newline += '    nnet::leaky_relu<{}, {}, {}>({}, {}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, activation_param, output_object)
-                    elif layer_list[i-1]['activation'] == "ThresholdedReLU":
-                        newline += '    nnet::thresholded_relu<{}, {}, {}>({}, {}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, activation_param, output_object)
-                    elif layer_list[i-1]['activation'].lower() == "elu":
-                        if activation_param:
-                            newline += '    nnet::elu<{}, {}, {}>({}, {}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, activation_param, output_object)
-                        else:
-                            newline += '    nnet::elu<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "selu":
-                        newline += '    nnet::selu<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "PReLU":
-                        newline += '    nnet::prelu<{}, {}, {}>({}, a{}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, i, output_object)
-                    elif layer_list[i-1]['activation'] == "softmax":
-                        newline += '    nnet::softmax<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "sigmoid":
-                        newline += '    nnet::sigmoid<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "hard_sigmoid":
-                        newline += '    nnet::hard_sigmoid<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "tanh":
-                        newline += '    nnet::tanh<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "linear": 
-                        #github Issue 53
-                        newline += '    nnet::linear<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "softsign":
-                        newline += '    nnet::softsign<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "softplus":
-                        newline += '    nnet::softplus<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object)
-                    elif layer_list[i-1]['activation'] == "binary_tanh":	
-                        newline += '    nnet::binary_tanh<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object) 
-                    elif layer_list[i-1]['activation'] == "ternary_tanh":	
-                        newline += '    nnet::ternary_tanh<{}, {}, {}>({}, {});\n'.format(act_input_type, output_type, activation_name, act_input_object, output_object) 
-                    else:
-                        raise Exception('ERROR: MISSING ACTIVATION')
-
-                newline += '\n'
-
-        #Just copy line
-        else: 
-            newline = line
-        fout.write(newline)
-    for sublayerline in sublayerlines:
-        fout.write('\n')
-        fout.write(sublayerline)
-        fout.write('\n')
-    f.close()
-    fout.close()
-
-    ###################
-    ## parameters.h
-    ###################
-
-    f = open(os.path.join(filedir,'../hls-template/firmware/parameters.h'),'r')
-    fout = open('{}/firmware/parameters.h'.format(yamlConfig['OutputDir']),'w')
-
-    dense_config_template = """struct config{index} : nnet::layer_config {{
-        static const unsigned n_in = {n_in};
-        static const unsigned n_out = {n_out};
-        static const unsigned io_type = nnet::{iotype};
-        static const unsigned reuse_factor = {reuse};
-        static const unsigned n_zeros = {nzeros};
-        static const bool store_weights_in_bram = false;
-        typedef accum_default_t accum_t;
-        typedef bias_default_t bias_t;
-        typedef weight_default_t weight_t;
-        }};\n"""
-
-    dense_sub_config_template = """struct config{index}_{i_part} : nnet::layer_config {{
-        static const unsigned n_in = {n_in};
-        static const unsigned n_out = {n_out};
-        static const unsigned io_type = nnet::{iotype};
-        static const unsigned reuse_factor = {reuse};
-        static const unsigned n_zeros = {nzeros};
-        static const bool store_weights_in_bram = false;
-        typedef accum_default_t accum_t;
-        typedef bias_default_t bias_t;
-        typedef weight_default_t weight_t;
-        }};\n"""
-
-    batchnorm_config_template = """struct config{index} : nnet::batchnorm_config {{
-        static const unsigned n_in = {n_in};
-        static const unsigned n_filt = {n_filt};
-        static const unsigned io_type = nnet::{iotype};
-        static const unsigned reuse_factor = {reuse};
-        static const bool store_weights_in_bram = false;
-        typedef beta_default_t beta_t;
-        typedef scale_default_t scale_t;
-        typedef mean_default_t mean_t;
-        }};\n"""
-
-    conv_config_template = """struct config{index} : nnet::conv_config {{
-        static const unsigned pad_left = {pad_left};
-        static const unsigned pad_right = {pad_right};
-        static const unsigned y_in = {y_in};
-        static const unsigned n_chan = {n_chan};
-        static const unsigned y_filt = {y_filt};
-        static const unsigned n_filt = {n_filt};
-        static const unsigned stride = {stride};
-        static const unsigned y_out = {y_out};
-        static const unsigned reuse_factor = {reuse};
-        static const unsigned n_zeros = {nzeros};
-        static const bool store_weights_in_bram = false;
-        typedef accum_default_t accum_t;
-        typedef bias_default_t bias_t;
-        typedef weight_default_t weight_t;
-        }};\n"""
-
-    conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
-        static const unsigned pad_top = {pad_top};
-        static const unsigned pad_bottom = {pad_bottom};
-        static const unsigned pad_left = {pad_left};
-        static const unsigned pad_right = {pad_right};
-        static const unsigned in_height = {in_height};
-        static const unsigned in_width = {in_width};
-        static const unsigned n_chan = {n_chan};
-        static const unsigned filt_height = {filt_height};
-        static const unsigned filt_width = {filt_width};
-        static const unsigned n_filt = {n_filt};
-        static const unsigned stride_height = {stride_height};
-        static const unsigned stride_width = {stride_width};
-        static const unsigned out_height = {out_height};
-        static const unsigned out_width = {out_width};
-        static const unsigned reuse_factor = {reuse};
-        static const unsigned n_zeros = {nzeros};
-        static const bool store_weights_in_bram = false;
-        typedef accum_default_t accum_t;
-        typedef bias_default_t bias_t;
-        typedef weight_default_t weight_t;
-        }};\n"""
-    
-    
-
-    activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
-        static const unsigned n_in = {n_in};
-        static const unsigned table_size = 1024;
-        static const unsigned io_type = nnet::{iotype};
-        }};\n"""
-
-    pooling1d_config_template = """struct config{index} : nnet::pooling1d_config {{
-        static const unsigned n_in = {n_in};
-        static const unsigned pool_size = {pool_size};
-        static const unsigned n_out = {n_out};
-        static const unsigned pad_left = {pad_left};
-        static const unsigned pad_right = {pad_right};
-        static const unsigned stride = {stride};
-        static const nnet::Pool_Op pool_op = nnet::{Op};
-    }};\n"""
-
-    pooling2d_config_template = """struct config{index} : nnet::pooling2d_config {{
-        static const unsigned in_height = {in_height};
-        static const unsigned in_width = {in_width};
-        static const unsigned n_filt = {n_filt};
-        static const unsigned stride_height = {stride_height};
-        static const unsigned stride_width = {stride_width};
-        static const unsigned pool_height = {pool_height};
-        static const unsigned pool_width = {pool_width};
-        static const unsigned out_height = {out_height};
-        static const unsigned out_width = {out_width};
-        static const unsigned pad_top = {pad_top};
-        static const unsigned pad_bottom = {pad_bottom};
-        static const unsigned pad_left = {pad_left};
-        static const unsigned pad_right = {pad_right};
-        static const nnet::Pool_Op pool_op = nnet::{Op};
-        static const unsigned reuse = {reuse};
-    }};\n
-    """
-
-    for line in f.readlines():
-
-        #Insert numbers
-        if '//hls-fpga-machine-learning insert numbers' in line:
-            newline = line
-            newline += 'typedef {precision} accum_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-            newline += 'typedef {precision} weight_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-            newline += 'typedef {precision} bias_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-            newline += 'typedef {precision} input_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-            newline += 'typedef {precision} result_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-            if do_batchnorm:
-             newline += 'typedef {precision} beta_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-             newline += 'typedef {precision} mean_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-             newline += 'typedef {precision} scale_default_t;\n'.format(precision=yamlConfig["DefaultPrecision"])
-
-            for i in range(1,len(layer_list)+1):
-                if i==1 and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense'):
-                    newline += '#define N_INPUTS {}\n'.format(layer_list[i-1]['n_in'])
-                    newline += '#define N_LAYER_1 {}\n'.format(layer_list[i-1]['n_out'])
-                elif i==1 and layer_list[i-1]['class_name']=='BatchNormalization' and is_dense:
-                    newline += '#define N_INPUTS {}\n'.format(layer_list[i-1]['n_in'])
-                    newline += '#define N_LAYER_1 {}\n'.format(layer_list[i-1]['n_out'])
-                    newline += '#define N_FILT_1 {}\n'.format(layer_list[i-1]['n_filt'])
-                elif i==1 and layer_list[i-1]['class_name']=='BatchNormalization' and is_conv2d:
-                    newline += '#define N_INPUTS {}\n'.format(layer_list[i-1]['n_in'])
-                    newline += '#define N_LAYER_{} {}\n'.format(i,layer_list[i-1]['n_out'])
-                    newline += '#define IN_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['in_height'])
-                    newline += '#define IN_WIDTH_{} {}\n'.format(i, layer_list[i-1]['in_width'])
-                    newline += '#define N_FILT_{} {}\n'.format(i, layer_list[i-1]['n_filt'])
-                elif i==len(layer_list) and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense'):
-                    newline += '#define N_OUTPUTS {}\n'.format(layer_list[i-1]['n_out'])
-                elif i==len(layer_list) and layer_list[i-1]['class_name'] in activation_layers:
-                    newline += '#define N_OUTPUTS {}\n'.format(layer_list[i-2]['n_out']) 
-                elif i==len(layer_list) and layer_list[i-1]['class_name']=='BatchNormalization':
-                    newline += '#define N_OUTPUTS {}\n'.format(layer_list[i-1]['n_out']) 
-                    newline += '#define N_FILT_{} {}\n'.format(i-1, layer_list[i-1]['n_filt']) 
-                elif layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense':
-                    newline += '#define N_LAYER_{} {}\n'.format(i, layer_list[i-1]['n_out'])    
-                elif is_dense and layer_list[i-1]['class_name']=='BatchNormalization':
-                    newline += '#define N_LAYER_{} {}\n'.format(i, layer_list[i-1]['n_out'])  
-                    newline += '#define N_FILT_{} {}\n'.format(i-1, layer_list[i-1]['n_filt']) 	
-                elif layer_list[i-1]['class_name'] in activation_layers:        
-                    newline += '#define N_LAYER_{} {}\n'.format(i, layer_list[i-2]['n_out'])
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    newline += '#define Y_INPUTS_{} {}\n'.format(i, layer_list[i-1]['y_in'])
-                    newline += '#define N_CHAN_{} {}\n'.format(i, layer_list[i-1]['n_chan'])
-                    newline += '#define Y_OUTPUTS_{} {}\n'.format(i, layer_list[i-1]['y_out'])
-                    newline += '#define N_FILT_{} {}\n'.format(i, layer_list[i-1]['n_filt'])
-                elif layer_list[i-1]['class_name']=='Conv2D':
-                    newline += '#define IN_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['in_height'])
-                    newline += '#define IN_WIDTH_{} {}\n'.format(i, layer_list[i-1]['in_width'])
-                    newline += '#define N_CHAN_{} {}\n'.format(i, layer_list[i-1]['n_chan'])
-                    newline += '#define OUT_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['out_height'])
-                    newline += '#define OUT_WIDTH_{} {}\n'.format(i, layer_list[i-1]['out_width'])
-                    newline += '#define N_FILT_{} {}\n'.format(i, layer_list[i-1]['n_filt'])
-                elif layer_list[i-1]['class_name']=='BatchNormalization' and is_conv2d:
-                    newline += '#define N_LAYER_{} {}\n'.format(i, layer_list[i-1]['n_out']) 
-                    newline += '#define OUT_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['in_height'])
-                    newline += '#define OUT_WIDTH_{} {}\n'.format(i, layer_list[i-1]['in_width'])
-                    newline += '#define N_FILT_{} {}\n'.format(i, layer_list[i-1]['n_filt']) 
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    info = layer_list[i-1]['class_name'].split('Pooling')
-                    d = int(info[1].split('D')[0])
-                    op = info[0]
-                    if d == 1:
-                        newline += '#define Y_INPUTS_{} {}\n'.format(i, layer_list[i-1]['y_in'])
-                        newline += '#define Y_OUTPUTS_{} {}\n'.format(i, layer_list[i-1]['y_out'])
-                        newline += '#define POOL_SIZE_{} {}\n'.format(i, layer_list[i-1]['pool_size'])
-                    elif d == 2:
-                        newline += '#define IN_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['in_height'])
-                        newline += '#define IN_WIDTH_{} {}\n'.format(i, layer_list[i-1]['in_width'])
-                        newline += '#define OUT_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['out_height'])
-                        newline += '#define OUT_WIDTH_{} {}\n'.format(i, layer_list[i-1]['out_width'])
-                        newline += '#define POOL_HEIGHT_{} {}\n'.format(i, layer_list[i-1]['pool_height'])
-                        newline += '#define POOL_WIDTH_{} {}\n'.format(i, layer_list[i-1]['pool_width'])
-                        newline += '#define N_FILT_{} {}\n'.format(i, layer_list[i-1]['n_filt'])
-                        newline += '#define N_LAYER_{} {}\n'.format(i, layer_list[i-1]['n_out'])
-
-
-        elif '//hls-fpga-machine-learning insert layer-precision' in line:
-            newline = line
-            for i in range(1,len(layer_list)):
-            #    if layer_list[i-1]['class_name']=='Dense':
-            #        newline += 'typedef {precision} layer{index}_t;\n'.format(precision=yamlConfig["DefaultPrecision"], index=i)
-                newline += 'typedef {precision} layer{index}_t;\n'.format(precision=yamlConfig["DefaultPrecision"], index=i)
-
-        elif "//hls-fpga-machine-learning insert layer-config" in line:
-            newline = line
-            for i in range(1,len(layer_list)+1):
-                if i==1 and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or layer_list[i-1]['class_name']=='BatchNormalization'):
-                    layer_in_name = "N_INPUTS"
-                    layer_out_name = "N_LAYER_1"                        
-                    layer_n_filt_name = "N_FILT_1"
-                elif i==1 and layer_list[i-1]['class_name']=='BatchNormalization' and is_conv2d:
-                    layer_in_name = "IN_HEIGHT_{}*IN_WIDTH_{}*N_FILT_{}".format(i, i, i)
-                    layer_out_name = "N_LAYER_1"       
-                    layer_n_filt_name = "N_FILT_{}".format(i)
-                elif i==1 and layer_list[i-1]['class_name']=='BatchNormalization' and is_dense:
-                    layer_in_name = "N_INPUTS"
-                    layer_out_name = "N_LAYER_1"       
-                    layer_n_filt_name = "N_FILT_{}".format(i)
-                elif is_dense and layer_list[i-1]['class_name']=='BatchNormalization':
-                    layer_in_name = "N_LAYER_{}".format(i-1)
-                    layer_out_name = "N_LAYER_{}".format(i)
-                    layer_n_filt_name = "N_FILT_{}".format(i-1)
-                elif i==len(layer_list) and layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv1D':
-                    layer_in_name = "Y_OUTPUTS_{}*N_FILT_{}".format(i-1, i-1)
-                    layer_out_name = "N_OUTPUTS"
-                elif i==len(layer_list) and layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv2D':
-                    layer_in_name = "OUT_HEIGHT_{}*OUT_WIDTH_{}*N_FILT_{}".format(i-1, i-1, i-1)
-                    layer_out_name = "N_OUTPUTS"
-                elif layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv1D':
-                    layer_in_name = "Y_OUTPUTS_{}*N_FILT_{}".format(i-1, i-1)
-                    layer_out_name = "N_LAYER_{}".format(i)   
-                elif layer_list[i-1]['class_name']=='Dense' and layer_list[i-2]['class_name']=='Conv2D':
-                    layer_in_name = "OUT_HEIGHT_{}*OUT_WIDTH_{}*N_FILT_{}".format(i-1, i-1, i-1)
-                    layer_out_name = "N_LAYER_{}".format(i)   
-                elif i==len(layer_list) and (layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or (is_dense and layer_list[i-1]['class_name'] in activation_layers) or (is_dense and layer_list[i-1]['class_name']=='BatchNormalization')):
-                    layer_in_name = "N_LAYER_{}".format(i-1)
-                    layer_out_name = "N_OUTPUTS"               
-                elif layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense' or (is_dense and layer_list[i-1]['class_name'] in activation_layers):
-                    layer_in_name = "N_LAYER_{}".format(i-1)
-                    layer_out_name = "N_LAYER_{}".format(i)
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    layer_y_in_name = "Y_INPUTS_{}".format(i)
-                    layer_n_chan_name = "N_CHAN_{}".format(i)
-                    layer_y_out_name = "Y_OUTPUTS_{}".format(i)
-                    layer_n_filt_name = "N_FILT_{}".format(i)
-                elif layer_list[i-1]['class_name']=='Conv2D': #or (is_conv2d and layer_list[i-1]['class_name']=='BatchNormalization'):
-                    layer_in_height_name = "IN_HEIGHT_{}".format(i)
-                    layer_in_width_name = "IN_WIDTH_{}".format(i)
-                    layer_n_chan_name = "N_CHAN_{}".format(i)
-                    layer_out_height_name = "OUT_HEIGHT_{}".format(i)
-                    layer_out_width_name = "OUT_WIDTH_{}".format(i)
-                    layer_n_filt_name = "N_FILT_{}".format(i)
-                    layer_in_name = "N_LAYER_{}".format(i-1)
-                elif is_conv2d and layer_list[i-1]['class_name']=='BatchNormalization':
-                    layer_in_name = "OUT_HEIGHT_{}*OUT_WIDTH_{}*N_FILT_{}".format(i-1, i-1, i-1)
-                    layer_out_name = "N_LAYER_{}".format(i)
-                    layer_n_filt_name = "N_FILT_{}".format(i-1)
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    info = layer_list[i-1]['class_name'].split('Pooling')
-                    d = int(info[1].split('D')[0])
-                    op = info[0]
-                    if d == 1:
-                        layer_y_in_name = "Y_INPUTS_{}".format(i)
-                        layer_y_out_name = "Y_OUTPUTS_{}".format(i)
-                        layer_n_filt_name = "N_FILT_{}".format(i)
-                    elif d == 2:
-                        layer_in_height_name = "IN_HEIGHT_{}".format(i)
-                        layer_in_width_name = "IN_WIDTH_{}".format(i)
-                        layer_out_height_name = "OUT_HEIGHT_{}".format(i)
-                        layer_out_width_name = "OUT_WIDTH_{}".format(i)
-                        layer_n_filt_name = "N_FILT_{}".format(i)
-                        layer_in_name = "N_LAYER_{}".format(i-1)
-                if layer_list[i-1]['class_name']=='Dense' or layer_list[i-1]['class_name']=='BinaryDense' or layer_list[i-1]['class_name']=='TernaryDense':
-                    if layer_list[i-1]['n_part']==1:
-                        newline += dense_config_template.format(index=str(i), 
-                                                                n_in=layer_in_name, 
-                                                                n_out=layer_out_name,
-                                                                iotype=yamlConfig["IOType"],
-                                                                reuse=yamlConfig["ReuseFactor"],
-                                                                nzeros=layer_list[i-1]['weights_n_zeros'])
-                    else:
-                        for i_part in range(0, layer_list[i-1]['n_part']):
-                            newline += dense_sub_config_template.format(index=str(i),
-                                                                        i_part=i_part,
-                                                                        n_in=layer_in_name,
-                                                                        n_out=layer_list[i-1]['n_subout'][i_part],
-                                                                        iotype=yamlConfig["IOType"],
-                                                                        reuse=yamlConfig["ReuseFactor"],
-                                                                        nzeros=layer_list[i-1]['weights_n_subzeros'][i_part])
-
-                    newline += activ_config_template.format(type=layer_list[i-1]['activation'],
-                                                                    index=str(i), 
-                                                                    n_in=layer_out_name,
-                                                                    iotype=yamlConfig["IOType"]) 
-                elif layer_list[i-1]['class_name']=='BatchNormalization':
-                    newline += batchnorm_config_template.format(index=str(i), 
-                                                            n_in=layer_in_name, 
-                                                            n_out=layer_out_name,
-                                                            n_filt=layer_n_filt_name,
-                                                            iotype=yamlConfig["IOType"],
-                                                            reuse=yamlConfig["ReuseFactor"])
-                elif layer_list[i-1]['class_name'] in activation_layers:	
-                    newline += activ_config_template.format(type=layer_list[i-1]['activation'],
-                                                                    index=str(i), 
-                                                                    n_in=layer_out_name,
-                                                                    iotype=yamlConfig["IOType"]) 
- 
-                elif layer_list[i-1]['class_name']=='Conv1D':
-                    newline += conv_config_template.format(index=str(i), 
-                                                            pad_left=layer_list[i-1]['pad_left'], 
-                                                            pad_right=layer_list[i-1]['pad_right'],
-                                                            y_in=layer_y_in_name,
-                                                            n_chan=layer_n_chan_name,
-                                                            y_out=layer_y_out_name,
-                                                            n_filt=layer_n_filt_name,
-                                                            y_filt=layer_list[i-1]['y_filt'],
-                                                            stride=layer_list[i-1]['stride'],
-                                                            iotype=yamlConfig["IOType"],
-                                                            reuse=yamlConfig["ReuseFactor"],
-                                                            nzeros=layer_list[i-1]['weights_n_zeros'])
-
-                    newline += activ_config_template.format(type=layer_list[i-1]['activation'],
-                                                                    index=str(i), 
-                                                                    n_in='{}*{}'.format(layer_y_out_name,layer_n_filt_name),
-                                                                    iotype=yamlConfig["IOType"]) 
-
-                elif layer_list[i-1]['class_name']=='Conv2D':
-                    newline += conv2d_config_template.format(index=str(i), 
-                                                            pad_top=layer_list[i-1]['pad_top'], 
-                                                            pad_bottom=layer_list[i-1]['pad_bottom'],
-                                                            pad_left=layer_list[i-1]['pad_left'], 
-                                                            pad_right=layer_list[i-1]['pad_right'],
-                                                            in_height=layer_in_height_name,
-                                                            in_width=layer_in_width_name,
-                                                            n_chan=layer_n_chan_name,
-                                                            out_height=layer_out_height_name,
-                                                            out_width=layer_out_width_name,
-                                                            n_filt=layer_n_filt_name,
-                                                            filt_height=layer_list[i-1]['filt_height'],
-                                                            filt_width=layer_list[i-1]['filt_width'],
-                                                            stride_height=layer_list[i-1]['stride_height'],
-                                                            stride_width=layer_list[i-1]['stride_width'],
-                                                            iotype=yamlConfig["IOType"],
-                                                            reuse=yamlConfig["ReuseFactor"],
-                                                            nzeros=layer_list[i-1]['weights_n_zeros'])
-
-                    newline += activ_config_template.format(type=layer_list[i-1]['activation'],
-                                                                    index=str(i), 
-                                                                    n_in='{}*{}*{}'.format(layer_out_height_name,layer_out_width_name,layer_n_filt_name),
-                                                                    iotype=yamlConfig["IOType"]) 
-                elif 'Pooling' in layer_list[i-1]['class_name']:
-                    info = layer_list[i-1]['class_name'].split('Pooling')
-                    d = int(info[1].split('D')[0])
-                    op = info[0]
-                    if d == 1:
-                        newline += pooling1d_config_template.format(index=str(i),
-                                                                    n_in=layer_n_in,
-                                                                    n_out=layer_n_out,
-                                                                    stride=layer_list[i-1]['stride'],
-                                                                    pool_size=layer_list[i-1]['pool_size'],
-                                                                    pad_left=layer_list[i-1]['pad_left'],
-                                                                    pad_right=layer_list[i-1]['pad_right'],
-                                                                    Op=op)
-                    elif d == 2:
-                        newline += pooling2d_config_template.format(index=str(i),
-                                                                    in_height=layer_in_height_name,
-                                                                    in_width=layer_in_width_name,
-                                                                    out_height=layer_out_height_name,
-                                                                    out_width=layer_out_width_name,
-                                                                    n_filt=layer_n_filt_name,
-                                                                    stride_height=layer_list[i-1]['stride_height'],
-                                                                    stride_width=layer_list[i-1]['stride_width'],
-                                                                    pool_height=layer_list[i-1]['pool_height'],
-                                                                    pool_width=layer_list[i-1]['pool_width'],
-                                                                    pad_left=layer_list[i-1]['pad_left'],
-                                                                    pad_right=layer_list[i-1]['pad_right'],
-                                                                    pad_top=layer_list[i-1]['pad_top'],
-                                                                    pad_bottom=layer_list[i-1]['pad_bottom'],
-                                                                    Op=op,
-                                                                    reuse=yamlConfig["ReuseFactor"])
-
-        else:
-            newline = line
-        fout.write(newline)
-    f.close()
-    fout.close()
-
-    ###################
-    ## test bench
-    ###################
-
-    f = open(os.path.join(filedir,'../hls-template/myproject_test.cpp'),'r')
-    fout = open('{}/{}_test.cpp'.format(yamlConfig['OutputDir'], yamlConfig['ProjectName']),'w')
-
-    for line in f.readlines():
-
-        #Insert numbers
-        if 'myproject' in line:
-            newline = line.replace('myproject',yamlConfig['ProjectName'])
-        elif '//hls-fpga-machine-learning insert data' in line and (layer_list[0]['class_name']=='Dense' or layer_list[0]['class_name']=='BinaryDense' or layer_list[0]['class_name']=='TernaryDense' or (is_dense and layer_list[0]['class_name']=='BatchNormalization')):
-            newline = line
-            newline += '  input_t  data_str[N_INPUTS] = {'
-            for i in range(0,layer_list[0]['n_in']-1):
-                newline += '0,'
-            newline += '0};\n'
-        elif '//hls-fpga-machine-learning insert data' in line and layer_list[0]['class_name']=='Conv1D':
-            newline = line
-            newline += '  input_t  data_str[Y_INPUTS_1][N_CHAN_1] = {'
-            for i in range(0,layer_list[0]['y_in']*layer_list[0]['n_chan']-1):
-                newline += '0,'
-            newline += '0};\n'
-        elif '//hls-fpga-machine-learning insert data' in line and layer_list[0]['class_name']=='Conv2D':
-            newline = line
-            newline += '  input_t  data_str[IN_HEIGHT_1][IN_WIDTH_1][N_CHAN_1] = {'
-            for i in range(0,layer_list[0]['in_height']*layer_list[0]['in_width']*layer_list[0]['n_chan']-1):
-                newline += '0,'
-            newline += '0};\n'
-        elif '//hls-fpga-machine-learning insert data' in line and is_conv2d and layer_list[0]['class_name']=='BatchNormalization':
-            newline = line
-            newline += '  input_t  data_str[IN_HEIGHT_1][IN_WIDTH_1][N_FILT_1] = {'
-            for i in range(0,layer_list[0]['in_height']*layer_list[0]['in_width']*layer_list[0]['n_filt']-1):
-                newline += '0,'
-            newline += '0};\n'
-        else:
-            newline = line
-        fout.write(newline)
-    f.close()
-    fout.close()
-
-
-    #######################
-    ## myproject.h
-    #######################
-
-    f = open(os.path.join(filedir,'../hls-template/firmware/myproject.h'),'r')
-    fout = open('{}/firmware/{}.h'.format(yamlConfig['OutputDir'], yamlConfig['ProjectName']),'w')
-
-    for line in f.readlines():
-
-        if 'MYPROJECT' in line:
-            newline = line.replace('MYPROJECT',format(yamlConfig['ProjectName'].upper()))
-        elif 'void myproject(' in line:
-            newline = 'void {}(\n'.format(yamlConfig['ProjectName'])
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='Conv1D':
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[Y_INPUTS_1][N_CHAN_1]')
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='Conv2D':
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[IN_HEIGHT_1][IN_WIDTH_1][N_CHAN_1]')
-        elif 'input_t data[N_INPUTS]' in line and layer_list[0]['class_name']=='BatchNormalization' and is_conv2d:
-            newline = line.replace('input_t data[N_INPUTS]','input_t data[IN_HEIGHT_1][IN_WIDTH_1][N_FILT_1]')
-        elif '#endif' in line:
-            for sublayerline_h in sublayerlines_h:
-                fout.write(sublayerline_h)
-            fout.write('\n#endif\n')
-        else:
-            newline = line
-        fout.write(newline)
-
-    f.close()
-    fout.close()
-
-
-    #######################
-    ## build_prj.tcl
-    #######################
-
-    nnetdir = os.path.abspath(os.path.join(filedir, "../nnet_utils"))
-    relpath = os.path.relpath(nnetdir, start=yamlConfig['OutputDir'])
-
-    f = open(os.path.join(filedir,'../hls-template/build_prj.tcl'),'r')
-    fout = open('{}/build_prj.tcl'.format(yamlConfig['OutputDir']),'w')
-
-    for line in f.readlines():
-
-        line = line.replace('myproject',yamlConfig['ProjectName'])
-        line = line.replace('nnet_utils', relpath)
-
-        if 'set_part {xc7vx690tffg1927-2}' in line:
-            line = 'set_part {{{}}}\n'.format(yamlConfig['XilinxPart'])
-        elif 'create_clock -period 5 -name default' in line:
-            line = 'create_clock -period {} -name default\n'.format(yamlConfig['ClockPeriod'])
-
-        fout.write(line)
-    f.close()
-    fout.close()
-
-
-    ###################
-    # Tarball output
-    ###################
-    with tarfile.open(yamlConfig['OutputDir'] + '.tar.gz', mode='w:gz') as archive:
-        archive.add(yamlConfig['OutputDir'], recursive=True)
-
-
+from collections import OrderedDict
 
 #######################################
 ## Config module
@@ -919,36 +17,17 @@ def parse_config(config_file) :
     return yaml.load(config)
 
 #######################################
-## Print a bias or weight array to C++
+## Print weight array to C++
 #######################################
-def print_array_to_cpp(name, a, odir, quantize=0, i_part = 0, n_part = 1, i_subout = 0, n_subout = 1):
+def print_array_to_cpp(name, a, odir, i_part = 0, n_part = 1, i_subout = 0, n_subout = 1):
 
-    #put output in subdir for tarballing later
-    #check if we're doing sublayer
-    if n_part > 1:
-        f=open("{}/firmware/weights/{}_{}.h".format(odir,name,i_part),"w")
-        if len(a.shape)==2: # dense weight
-            a = a[:,i_subout:i_subout+n_subout]
-        elif len(a.shape)==1: # bias
-            a = a[i_subout:i_subout+n_subout]
-    else:
-        f=open("{}/firmware/weights/{}.h".format(odir,name),"w")
+    f=open("{}/firmware/weights/{}.h".format(odir,name),"w")
 
     #count zeros
     zero_ctr = 0
     for x in np.nditer(a, order='C'):
-        if x == 0: 
+        if x == 0:
             zero_ctr += 1
-
-    #quantize weights if BinaryDense or TernaryDense
-    if quantize == 2:
-     a[a>0] = 1
-     a[a<=0] = -1
-    elif quantize == 3:
-     ones = np.ones_like(a)
-     zeros = np.zeros_like(a)
-     at = np.where(a > 0.5, ones, np.where(a <= -0.5, -ones, zeros))
-     a = at
 
     #meta data
     f.write("//Numpy array shape {}\n".format(a.shape))
@@ -956,7 +35,7 @@ def print_array_to_cpp(name, a, odir, quantize=0, i_part = 0, n_part = 1, i_subo
     f.write("//Max {:.12f}\n".format(np.max(a)))
     f.write("//Number of zeros {}\n".format(zero_ctr))
     f.write("\n")
-    
+
     #c++ variable
     if re.match(r"^w\d*$", name) or re.match(r"^a\d*$", name):
         if n_part > 1:
@@ -969,7 +48,7 @@ def print_array_to_cpp(name, a, odir, quantize=0, i_part = 0, n_part = 1, i_subo
         else:
             f.write("bias_default_t {}".format(name))
     elif re.match(r"^beta\d*$", name):
-        f.write("beta_default_t {}".format(name))	
+        f.write("beta_default_t {}".format(name))
     elif re.match(r"^mean\d*$", name):
         f.write("mean_default_t {}".format(name))
     elif re.match(r"^scale\d*$", name):
@@ -981,8 +60,8 @@ def print_array_to_cpp(name, a, odir, quantize=0, i_part = 0, n_part = 1, i_subo
     #also doing for all (including 2d) arrays now
     f.write("[{}]".format(np.prod(a.shape)))
     f.write(" = {")
-    
-    #fill c++ array.  
+
+    #fill c++ array.
     #not including internal brackets for multidimensional case
     i=0
     for x in np.nditer(a, order='C'):
@@ -995,3 +74,260 @@ def print_array_to_cpp(name, a, odir, quantize=0, i_part = 0, n_part = 1, i_subo
     f.close()
 
     return zero_ctr
+
+def write_project_cpp(model):
+    ###################
+    ## myproject.cpp
+    ###################
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    f = open(os.path.join(filedir,'../hls-template/firmware/myproject.cpp'),'r')
+    fout = open('{}/firmware/{}.cpp'.format(model.get_output_dir(), model.get_project_name()),'w')
+
+    model_inputs = model.get_input_variables()
+    model_outputs = model.get_output_variables()
+
+    indent = '    '
+
+    for line in f.readlines():
+        #Add headers to weights and biases
+        if 'myproject' in line:
+            newline = line.replace('myproject', model.get_project_name())
+        elif '//hls-fpga-machine-learning insert header' in line:
+            inputs_str = ', '.join([i.definition_cpp() for i in model_inputs])
+            outputs_str = ', '.join([o.definition_cpp() for o in model_outputs])
+            insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
+            outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(i) for i in range(1, len(model_outputs) + 1)])
+
+            newline = ''
+            newline += indent + inputs_str + ',\n'
+            newline += indent + outputs_str + ',\n'
+            newline += indent + insize_str + ',\n'
+            newline += indent + outsize_str + '\n'
+
+        elif '//hls-fpga-machine-learning insert weights' in line:
+            newline = line
+            for layer in model.get_layers():
+                for w in layer.get_weights():
+                    newline += '#include "weights/{}.h"\n'.format(w.name)
+
+        #Add input/output type
+        elif '//hls-fpga-machine-learning insert IO' in line:
+            newline = line
+            all_inputs = [i.name for i in model_inputs]
+            all_outputs = [o.name for o in model_outputs]
+            if model.get_config_value("IOType") == "io_parallel":
+                for i in model_inputs: newline += indent + '#pragma HLS ARRAY_RESHAPE variable={} complete dim=0 \n'.format(i.name)
+                for o in model_outputs: newline += indent + '#pragma HLS ARRAY_RESHAPE variable={} complete dim=0 \n'.format(o.name)
+                newline += indent + '#pragma HLS INTERFACE ap_vld port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
+                newline += indent + '#pragma HLS PIPELINE \n'
+            if model.get_config_value("IOType") == "io_serial":
+                newline += indent + '#pragma HLS INTERFACE axis port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
+                newline += indent + '#pragma HLS DATAFLOW \n'
+
+            inval_str = '\n    '.join(['const_size_in_{} = {};'.format(i, inp.size_cpp()) for i, inp in enumerate(model_inputs, 1)])
+            outval_str = '\n    '.join(['const_size_out_{} = {};'.format(i, out.size_cpp()) for i, out in enumerate(model_outputs, 1)])
+            newline += '\n' + indent + inval_str
+            newline += '\n' + indent + outval_str
+
+        elif '//hls-fpga-machine-learning insert layers' in line:
+            newline = line + '\n'
+            inputs = model.get_input_variables()
+            outputs = model.get_output_variables()
+            for layer in model.get_layers():
+                vars = layer.get_variables()
+                for var in vars:
+                    if var not in inputs and var not in outputs:
+                        newline += '    ' + var.definition_cpp() + ';\n'
+                        if var.pragma:
+                            newline += '    ' + var.pragma + '\n'
+                func = layer.function_cpp()
+                if func:
+                    for line in func:
+                        newline += '    ' + line + '\n'
+                    newline += '\n'
+
+        #Just copy line
+        else:
+            newline = line
+
+        fout.write(newline)
+
+    f.close()
+    fout.close()
+
+def write_project_header(model):
+    #######################
+    ## myproject.h
+    #######################
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    f = open(os.path.join(filedir,'../hls-template/firmware/myproject.h'),'r')
+    fout = open('{}/firmware/{}.h'.format(model.get_output_dir(), model.get_project_name()),'w')
+
+    model_inputs = model.get_input_variables()
+    model_outputs = model.get_output_variables()
+
+    indent = '    '
+
+    for line in f.readlines():
+
+        if 'MYPROJECT' in line:
+            newline = line.replace('MYPROJECT',format(model.get_project_name().upper()))
+        elif 'void myproject(' in line:
+            newline = 'void {}(\n'.format(model.get_project_name())
+        elif '//hls-fpga-machine-learning insert header' in line:
+            inputs_str = ', '.join([i.definition_cpp() for i in model_inputs])
+            outputs_str = ', '.join([o.definition_cpp() for o in model_outputs])
+            insize_str = ', '.join(['unsigned short &const_size_in_{}'.format(i) for i in range(1, len(model_inputs) + 1)])
+            outsize_str = ', '.join(['unsigned short &const_size_out_{}'.format(o) for o in range(1, len(model_outputs) + 1)])
+
+            newline = ''
+            newline += indent + inputs_str + ',\n'
+            newline += indent + outputs_str + ',\n'
+            newline += indent + insize_str + ',\n'
+            newline += indent + outsize_str + '\n'
+        else:
+            newline = line
+        fout.write(newline)
+
+    f.close()
+    fout.close()
+
+def write_parameters(model):
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    f = open(os.path.join(filedir,'../hls-template/firmware/parameters.h'),'r')
+    fout = open('{}/firmware/parameters.h'.format(model.get_output_dir()),'w')
+
+    for line in f.readlines():
+
+        #Insert numbers
+        if '//hls-fpga-machine-learning insert numbers' in line:
+            newline = line
+            newline += 'typedef {precision} accum_default_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} weight_default_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} bias_default_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} input_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} result_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} beta_default_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} mean_default_t;\n'.format(precision=model.get_default_precision())
+            newline += 'typedef {precision} scale_default_t;\n'.format(precision=model.get_default_precision())
+
+            newline += '\n'
+
+            numbers = OrderedDict.fromkeys([layer.get_numbers_cpp() for layer in model.get_layers()])
+            newline += ''.join(numbers)
+
+        elif '//hls-fpga-machine-learning insert layer-precision' in line:
+            newline = line
+            for layer in model.get_layers():
+                newline += layer.precision_cpp() + '\n'
+
+        elif "//hls-fpga-machine-learning insert layer-config" in line:
+            newline = line
+            for layer in model.get_layers():
+                config = layer.config_cpp()
+                if config:
+                    newline += config + '\n'
+        else:
+            newline = line
+        fout.write(newline)
+    f.close()
+    fout.close()
+
+def write_weights(model):
+    for layer in model.get_layers():
+        for weights in layer.get_weights():
+            print_array_to_cpp(weights.name, weights.data, model.get_output_dir())
+
+def write_test_bench(model):
+    ###################
+    ## test bench
+    ###################
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    f = open(os.path.join(filedir,'../hls-template/myproject_test.cpp'),'r')
+    fout = open('{}/{}_test.cpp'.format(model.get_output_dir(), model.get_project_name()),'w')
+
+    for line in f.readlines():
+
+        #Insert numbers
+        if 'myproject' in line:
+            newline = line.replace('myproject', model.get_project_name())
+        elif '//hls-fpga-machine-learning insert data' in line:
+            newline = line
+            for inp in model.get_input_variables():
+                input_str = '  ' + inp.definition_cpp() + ' = {};\n'
+                default_val = ','.join(str(i) for i in [0] * inp.size())
+                newline += input_str.format('{' + default_val + '}')
+            for out in model.get_output_variables():
+                output_str = '  ' + out.definition_cpp() + ' = {};\n'
+                default_val = ','.join(str(o) for o in [0] * out.size())
+                newline += output_str.format('{' + default_val + '}')
+        elif '//hls-fpga-machine-learning insert top-level-function' in line:
+            newline = line
+
+            size_str = '  unsigned short {},{};\n'
+            input_size_vars = ','.join(['size_in{}'.format(i) for i in range(1, len(model.get_input_variables()) + 1)])
+            output_size_vars = ','.join(['size_out{}'.format(o) for o in range(1, len(model.get_output_variables()) + 1)])
+            newline += size_str.format(input_size_vars, output_size_vars)
+
+            input_vars = ','.join([i.name for i in model.get_input_variables()])
+            output_vars = ','.join([o.name for o in model.get_output_variables()])
+            top_level = '  {}({},{},{},{});\n'.format(model.get_project_name(), input_vars, output_vars, input_size_vars, output_size_vars)
+            newline += top_level
+        elif '//hls-fpga-machine-learning insert output' in line:
+            newline = line
+            for out in model.get_output_variables():
+                newline += '  for(int i = 0; i < {}; i++) {{\n'.format(out.size_cpp())
+                newline += '    std::cout << {}[i] << " ";\n'.format(out.name)
+                newline += '  }\n'
+                newline += '  std::cout << std::endl;\n'
+        else:
+            newline = line
+        fout.write(newline)
+    f.close()
+    fout.close()
+
+def write_build_script(model):
+    ###################
+    # build_prj.tcl
+    ###################
+
+    filedir = os.path.dirname(os.path.abspath(__file__))
+    nnetdir = os.path.abspath(os.path.join(filedir, "../nnet_utils"))
+    relpath = os.path.relpath(nnetdir, start=model.get_output_dir())
+
+    f = open(os.path.join(filedir,'../hls-template/build_prj.tcl'),'r')
+    fout = open('{}/build_prj.tcl'.format(model.get_output_dir()),'w')
+
+    for line in f.readlines():
+
+        line = line.replace('myproject',model.get_project_name())
+        line = line.replace('nnet_utils', relpath)
+
+        if 'set_part {xc7vx690tffg1927-2}' in line:
+            line = 'set_part {{{}}}\n'.format(model.get_config_value('XilinxPart'))
+        elif 'create_clock -period 5 -name default' in line:
+            line = 'create_clock -period {} -name default\n'.format(model.get_config_value('ClockPeriod'))
+
+        fout.write(line)
+    f.close()
+    fout.close()
+
+def write_tar(model):
+    ###################
+    # Tarball output
+    ###################
+
+    with tarfile.open(model.get_output_dir() + '.tar.gz', mode='w:gz') as archive:
+        archive.add(model.get_output_dir(), recursive=True)
+
+def write_hls(model):
+    write_project_cpp(model)
+    write_project_header(model)
+    write_weights(model)
+    write_parameters(model)
+    write_test_bench(model)
+    write_build_script(model)
+    write_tar(model)

--- a/hls-writer/templates.py
+++ b/hls-writer/templates.py
@@ -9,18 +9,18 @@ dense_config_template = """struct config{index} : nnet::dense_config {{
     typedef accum_default_t accum_t;
     typedef bias_default_t bias_t;
     typedef weight_default_t weight_t;
-    }};\n"""
+}};\n"""
 
 batchnorm_config_template = """struct config{index} : nnet::batchnorm_config {{
-   static const unsigned n_in = {n_in};
-   static const unsigned n_filt = {n_filt};
-   static const unsigned io_type = nnet::{iotype};
-   static const unsigned reuse_factor = {reuse};
-   static const bool store_weights_in_bram = false;
-   typedef beta_default_t beta_t;
-   typedef scale_default_t scale_t;
-   typedef mean_default_t mean_t;
-   }};\n"""
+    static const unsigned n_in = {n_in};
+    static const unsigned n_filt = {n_filt};
+    static const unsigned io_type = nnet::{iotype};
+    static const unsigned reuse_factor = {reuse};
+    static const bool store_weights_in_bram = false;
+    typedef beta_default_t beta_t;
+    typedef scale_default_t scale_t;
+    typedef mean_default_t mean_t;
+}};\n"""
 
 conv1d_config_template = """struct config{index} : nnet::conv1d_config {{
     static const unsigned pad_left = {pad_left};
@@ -37,7 +37,7 @@ conv1d_config_template = """struct config{index} : nnet::conv1d_config {{
     typedef accum_default_t accum_t;
     typedef bias_default_t bias_t;
     typedef weight_default_t weight_t;
-    }};\n"""
+}};\n"""
 
 conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
     static const unsigned pad_top = {pad_top};
@@ -60,13 +60,13 @@ conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
     typedef accum_default_t accum_t;
     typedef bias_default_t bias_t;
     typedef weight_default_t weight_t;
-    }};\n"""
+}};\n"""
 
 activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
     static const unsigned n_in = {n_in};
     static const unsigned table_size = 1024;
     static const unsigned io_type = nnet::{iotype};
-    }};\n"""
+}};\n"""
 
 pooling1d_config_template = """struct config{index} : nnet::pooling1d_config {{
     static const unsigned n_in = {n_in};

--- a/hls-writer/templates.py
+++ b/hls-writer/templates.py
@@ -1,0 +1,136 @@
+
+dense_config_template = """struct config{index} : nnet::dense_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned n_out = {n_out};
+    static const unsigned io_type = nnet::{iotype};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {nzeros};
+    static const bool store_weights_in_bram = false;
+    typedef accum_default_t accum_t;
+    typedef bias_default_t bias_t;
+    typedef weight_default_t weight_t;
+    }};\n"""
+
+batchnorm_config_template = """struct config{index} : nnet::batchnorm_config {{
+   static const unsigned n_in = {n_in};
+   static const unsigned n_filt = {n_filt};
+   static const unsigned io_type = nnet::{iotype};
+   static const unsigned reuse_factor = {reuse};
+   static const bool store_weights_in_bram = false;
+   typedef beta_default_t beta_t;
+   typedef scale_default_t scale_t;
+   typedef mean_default_t mean_t;
+   }};\n"""
+
+conv1d_config_template = """struct config{index} : nnet::conv1d_config {{
+    static const unsigned pad_left = {pad_left};
+    static const unsigned pad_right = {pad_right};
+    static const unsigned y_in = {y_in};
+    static const unsigned n_chan = {n_chan};
+    static const unsigned y_filt = {y_filt};
+    static const unsigned n_filt = {n_filt};
+    static const unsigned stride = {stride};
+    static const unsigned y_out = {y_out};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {nzeros};
+    static const bool store_weights_in_bram = false;
+    typedef accum_default_t accum_t;
+    typedef bias_default_t bias_t;
+    typedef weight_default_t weight_t;
+    }};\n"""
+
+conv2d_config_template = """struct config{index} : nnet::conv2d_config {{
+    static const unsigned pad_top = {pad_top};
+    static const unsigned pad_bottom = {pad_bottom};
+    static const unsigned pad_left = {pad_left};
+    static const unsigned pad_right = {pad_right};
+    static const unsigned in_height = {in_height};
+    static const unsigned in_width = {in_width};
+    static const unsigned n_chan = {n_chan};
+    static const unsigned filt_height = {filt_height};
+    static const unsigned filt_width = {filt_width};
+    static const unsigned n_filt = {n_filt};
+    static const unsigned stride_height = {stride_height};
+    static const unsigned stride_width = {stride_width};
+    static const unsigned out_height = {out_height};
+    static const unsigned out_width = {out_width};
+    static const unsigned reuse_factor = {reuse};
+    static const unsigned n_zeros = {nzeros};
+    static const bool store_weights_in_bram = false;
+    typedef accum_default_t accum_t;
+    typedef bias_default_t bias_t;
+    typedef weight_default_t weight_t;
+    }};\n"""
+
+activ_config_template = """struct {type}_config{index} : nnet::activ_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned table_size = 1024;
+    static const unsigned io_type = nnet::{iotype};
+    }};\n"""
+
+pooling1d_config_template = """struct config{index} : nnet::pooling1d_config {{
+    static const unsigned n_in = {n_in};
+    static const unsigned pool_size = {pool_size};
+    static const unsigned n_out = {n_out};
+    static const unsigned pad_left = {pad_left};
+    static const unsigned pad_right = {pad_right};
+    static const unsigned stride = {stride};
+    static const nnet::Pool_Op pool_op = nnet::{pool_op};
+}};\n"""
+
+pooling2d_config_template = """struct config{index} : nnet::pooling2d_config {{
+    static const unsigned in_height = {in_height};
+    static const unsigned in_width = {in_width};
+    static const unsigned n_filt = {n_filt};
+    static const unsigned stride_height = {stride_height};
+    static const unsigned stride_width = {stride_width};
+    static const unsigned pool_height = {pool_height};
+    static const unsigned pool_width = {pool_width};
+    static const unsigned out_height = {out_height};
+    static const unsigned out_width = {out_width};
+    static const unsigned pad_top = {pad_top};
+    static const unsigned pad_bottom = {pad_bottom};
+    static const unsigned pad_left = {pad_left};
+    static const unsigned pad_right = {pad_right};
+    static const nnet::Pool_Op pool_op = nnet::{pool_op};
+    static const unsigned reuse = {reuse};
+}};\n"""
+
+config_templates = {
+    'Dense'                  : dense_config_template,
+    'BatchNormalization'     : batchnorm_config_template,
+    'Conv1D'                 : conv1d_config_template,
+    'Conv2D'                 : conv2d_config_template,
+    'Activation'             : activ_config_template,
+    'ParametrizedActivation' : activ_config_template,
+    'PReLU'                  : activ_config_template,
+    'Pooling1D'              : pooling1d_config_template,
+    'Pooling2D'              : pooling2d_config_template,
+}
+
+dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
+batchnorm_function_template = 'nnet::normalize<{input_t}, {output_t}, {config}>({input}, {output}, {scale}, {beta}, {mean});'
+conv1d_function_template = 'nnet::conv_1d<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
+conv2d_function_template = 'nnet::conv_2d<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
+activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {output});'
+param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {param}, {output});'
+pooling1d_function_template = 'nnet::pooling1d<{input_t}, {config}>({input}, {output});'
+pooling2d_function_template = 'nnet::pooling2d<{input_t}, {config}>({input}, {output});'
+
+function_templates = {
+    'Dense'                  : dense_function_template,
+    'BatchNormalization'     : batchnorm_function_template,
+    'Conv1D'                 : conv1d_function_template,
+    'Conv2D'                 : conv2d_function_template,
+    'Activation'             : activ_function_template,
+    'ParametrizedActivation' : param_activ_function_template,
+    'PReLU'                  : param_activ_function_template,
+    'Pooling1D'              : pooling1d_function_template,
+    'Pooling2D'              : pooling2d_function_template,
+}
+
+def get_config_template(kind):
+    return config_templates.get(kind)
+
+def get_function_template(kind):
+    return function_templates.get(kind)

--- a/hls-writer/templates.py
+++ b/hls-writer/templates.py
@@ -96,6 +96,21 @@ pooling2d_config_template = """struct config{index} : nnet::pooling2d_config {{
     static const unsigned reuse = {reuse};
 }};\n"""
 
+merge_config_template = """struct config{index} : nnet::merge_config {{
+    static const unsigned n_elem = {n_elem};
+}};\n"""
+
+concat_config_template = """struct config{index} : nnet::concat_config {{
+    static const unsigned n_elem1_0 = {n_elem1_0};
+    static const unsigned n_elem1_1 = {n_elem1_1};
+    static const unsigned n_elem1_2 = {n_elem1_2};
+    static const unsigned n_elem2_0 = {n_elem2_0};
+    static const unsigned n_elem2_1 = {n_elem2_1};
+    static const unsigned n_elem2_2 = {n_elem2_2};
+
+    static const unsigned axis = {axis};
+}};\n"""
+
 config_templates = {
     'Dense'                  : dense_config_template,
     'BatchNormalization'     : batchnorm_config_template,
@@ -106,6 +121,8 @@ config_templates = {
     'PReLU'                  : activ_config_template,
     'Pooling1D'              : pooling1d_config_template,
     'Pooling2D'              : pooling2d_config_template,
+    'Merge'                  : merge_config_template,
+    'Concatenate'            : concat_config_template,
 }
 
 dense_function_template = 'nnet::dense<{input_t}, {output_t}, {config}>({input}, {output}, {w}, {b});'
@@ -116,6 +133,7 @@ activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({
 param_activ_function_template = 'nnet::{activation}<{input_t}, {output_t}, {config}>({input}, {param}, {output});'
 pooling1d_function_template = 'nnet::pooling1d<{input_t}, {config}>({input}, {output});'
 pooling2d_function_template = 'nnet::pooling2d<{input_t}, {config}>({input}, {output});'
+merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {config}>({input1}, {input2}, {output});'
 
 function_templates = {
     'Dense'                  : dense_function_template,
@@ -127,6 +145,8 @@ function_templates = {
     'PReLU'                  : param_activ_function_template,
     'Pooling1D'              : pooling1d_function_template,
     'Pooling2D'              : pooling2d_function_template,
+    'Merge'                  : merge_function_template,
+    'Concatenate'            : merge_function_template,
 }
 
 def get_config_template(kind):

--- a/keras-to-hls/keras-to-hls.py
+++ b/keras-to-hls/keras-to-hls.py
@@ -14,31 +14,38 @@ MAXMULT = 4096
 
 filedir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0,os.path.join(filedir, "..", "hls-writer"))
-from hls_writer import parse_config, print_array_to_cpp, hls_writer
+from hls_writer import parse_config, write_hls
+from hls_model import HLSModel
 
-def find_kernel_in_h5(name):
-    if 'kernel' in name:
-        return name
+class KerasDataReader:
+    def __init__(self, config):
+        self.config = config
 
-def find_bias_in_h5(name):
-    if 'bias' in name:
-        return name
+    def get_weights_data(self, layer_name, var_name):
+        def h5_visitor_func(name):
+            if var_name in name:
+                return name
 
-def find_beta_in_h5(name):
-    if 'beta' in name:
-        return name
+        with h5py.File(self.config['KerasH5'], 'r') as h5file:
+            found_data = h5file[layer_name].visit(h5_visitor_func)
+            if found_data:
+                data = h5file['/{}/{}'.format(layer_name,found_data)][()]
+            else:
+                data = None
 
-def find_moving_mean_in_h5(name):
-    if 'moving_mean' in name:
-        return name
+        return data
 
-def find_moving_variance_in_h5(name):
-    if 'moving_variance' in name:
-        return name
+def get_weights_shape(h5filename, layer_name, var_name='kernel'):
+    def h5_visitor_func(name):
+        if var_name in name:
+            return name
 
-def find_gamma_in_h5(name):
-    if 'gamma' in name:
-        return name
+    with h5py.File(h5filename, 'r') as h5file:
+        found_data = h5file[layer_name].visit(h5_visitor_func)
+        if found_data:
+            shape = h5file['/{}/{}'.format(layer_name,found_data)].shape
+
+    return shape
 
 ############################################################################################
 ## M A I N
@@ -61,7 +68,7 @@ def main():
     if not os.path.isabs(yamlConfig['KerasJson']):
         yamlConfig['KerasJson'] = os.path.join(configDir, yamlConfig['KerasJson'])
 
-    if not (yamlConfig["IOType"] == "io_parallel" or yamlConfig["IOType"] == "io_serial"): 
+    if not (yamlConfig["IOType"] == "io_parallel" or yamlConfig["IOType"] == "io_serial"):
         raise Exception('ERROR: Invalid IO type')
 
     ######################
@@ -69,8 +76,6 @@ def main():
     ######################
     if not os.path.isdir("{}/firmware/weights".format(yamlConfig['OutputDir'])):
         os.makedirs("{}/firmware/weights".format(yamlConfig['OutputDir']))
-
-    h5File = h5py.File( yamlConfig['KerasH5'], 'r' )
 
     #This is a list of dictionaries to hold all the layer info we need to generate HLS
     layer_list = []
@@ -85,19 +90,32 @@ def main():
     activation_layers = ['Activation', 'LeakyReLU', 'ThresholdedReLU', 'ELU', 'PReLU']
 
     #Define layers to skip for conversion to HLS
-    skip_layers = ['InputLayer','Dropout', 'Flatten'] 
+    skip_layers = ['Dropout', 'Flatten']
+    #Map inputs of skipped and split (activation) layers
+    inputs_map = {}
 
     #Loop through layers
     layer_counter = 0
-    input_layer = {}
+
+    input_layers = None
+    output_layers = None
 
     layer_config = None
     if model_arch['class_name'] == 'Sequential':
         print('Interpreting Sequential')
         layer_config = model_arch["config"]
+        # Sequential doesn't have InputLayer
+        input_layer = {}
+        input_layer['name'] = 'input1'
+        input_layer['class_name'] = 'InputLayer'
+        input_layer['input_shape'] = layer_config[0]['config']['batch_input_shape'][1:]
+        layer_list.append(input_layer)
+        print('Input shape:', input_layer['input_shape'])
     elif model_arch['class_name'] == 'Model':
         print('Interpreting Model')
         layer_config = model_arch["config"]["layers"]
+        input_layers = [ inp[0] for inp in model_arch["config"]["input_layers"] ]
+        output_layers = [ out[0] for out in model_arch["config"]["output_layers"] ]
 
     # Get input shape and check for unsupported layer type
     current_shape = None
@@ -105,29 +123,20 @@ def main():
         if keras_layer["class_name"] not in supported_layers + activation_layers:
             raise Exception('ERROR: Unsupported layer type: {}'.format(keras_layer["class_name"]))
         if 'batch_input_shape' in keras_layer['config']:
-            current_shape = keras_layer['config']['batch_input_shape'] # [None, 100, 7]    
-    print('Input shape:', current_shape)
+            current_shape = keras_layer['config']['batch_input_shape'] # [None, 100, 7]
 
-    # Set some variables to make the routine after a bit smoother
-    is_conv2d = False
-    is_dense = False
-    quantize = 0
-    for keras_layer in layer_config:
-     if keras_layer["class_name"]=='Conv2D':
-      is_conv2d = True
-      break
-     if keras_layer["class_name"]=='Dense' or keras_layer["class_name"]=='BinaryDense' or keras_layer["class_name"]=='TernaryDense':
-      is_dense = True
-      if keras_layer["class_name"]=='BinaryDense': quantize = 2
-      if keras_layer["class_name"]=='TernaryDense': quantize = 3
-      break
-	        
     print('Topology:')
-    for il,keras_layer in enumerate(layer_config):
+    for keras_layer in layer_config:
         if keras_layer["class_name"] is 'Flatten':
             current_shape = [current_shape[0], np.prod(current_shape[1:])]
         if keras_layer["class_name"] in skip_layers:
-            continue 
+            if 'inbound_nodes' in keras_layer:
+                name = keras_layer['config']['name']
+                #Currently supported skipped layers have only one input
+                parent_input = keras_layer['inbound_nodes'][0][0][0]
+                #Skipped layers can follow each other (e.g., Dropout -> Flatten)
+                inputs_map[name] = inputs_map.get(parent_input, parent_input)
+            continue
 
         if keras_layer["class_name"] in supported_layers + activation_layers:
             layer_counter = layer_counter + 1
@@ -139,84 +148,40 @@ def main():
         layer['name']=keras_layer['config']['name']
         layer['class_name']=keras_layer['class_name']
 
+        #Extract inbound nodes
+        if 'inbound_nodes' in keras_layer and len(keras_layer['inbound_nodes']) > 0:
+            layer['inputs'] = [ inputs_map.get(inp[0], inp[0]) for inp in keras_layer['inbound_nodes'][0] ]
+
         #Extract type of activation and number of nodes
         for config,config_value in keras_layer["config"].items():
             if(config=="activation"):
                 layer['activation']=config_value
             if(config=="epsilon"):
-                layer['epsilon']=config_value	
+                layer['epsilon']=config_value
             #if(config=="units"):
                 #print("PARSED NUM OF NODES",config_value)
 
-        
-        #Translate weights and biases from h5 file
-        if layer['class_name'] != 'BatchNormalization' and layer['class_name'] not in activation_layers and 'Pooling' not in layer['class_name']:
-            found_weights = h5File[layer['name']].visit(find_kernel_in_h5)
-            weights = h5File['/{}/{}'.format(layer['name'],found_weights)][()]
-            cur_n_zeros = print_array_to_cpp("w{}".format(layer_counter), weights, yamlConfig['OutputDir'],quantize)
-            found_bias = h5File[layer['name']].visit(find_bias_in_h5)
-            if found_bias: biases = h5File['/{}/{}'.format(layer['name'],found_bias)][()]
-            else: biases = np.zeros(weights.shape[1]) 
-            print_array_to_cpp("b{}".format(layer_counter), biases, yamlConfig['OutputDir'])
-            layer['weights_n_zeros'] = cur_n_zeros
-        elif layer['class_name'] == 'BatchNormalization':
-            cur_n_zeros = []
-            layer['weights_n_zeros'] = cur_n_zeros 
-            found_beta = h5File[layer['name']].visit(find_beta_in_h5)
-            beta = h5File['/{}/{}'.format(layer['name'],found_beta)][()]
-            print_array_to_cpp("beta{}".format(layer_counter), beta, yamlConfig['OutputDir'])
-            found_mean = h5File[layer['name']].visit(find_moving_mean_in_h5)
-            mean = h5File['/{}/{}'.format(layer['name'],found_mean)][()]
-            print_array_to_cpp("mean{}".format(layer_counter), mean, yamlConfig['OutputDir'])
-            found_gamma = h5File[layer['name']].visit(find_gamma_in_h5)
-            gamma = h5File['/{}/{}'.format(layer['name'],found_gamma)][()]
-            found_var = h5File[layer['name']].visit(find_moving_variance_in_h5)
-            var = h5File['/{}/{}'.format(layer['name'],found_var)][()]
-            var = var + layer['epsilon']
-            scale = gamma/np.sqrt(var)
-            print_array_to_cpp("scale{}".format(layer_counter), scale, yamlConfig['OutputDir'])
-        
-        # Skip activation layers if possible
-        skip_layer = False
         # Default one layer call
-        layer['n_part'] = 1
-        #Get number of inputs and outputs
-        #(We take it from the weights to avoid dealing with InputLayer and Flatten details)
-        if layer['class_name']=='Dense' or layer['class_name']=='BinaryDense' or layer['class_name']=='TernaryDense':
-            layer['n_in']=weights.shape[0]
-            layer['n_out']=weights.shape[1]
-            # if this layer is too big (more than MAXMULT multiplications); 
-            # break it out into chunks!
-            layer['n_subout']=[weights.shape[1]]
-            if layer['n_in']*layer['n_out']>MAXMULT and yamlConfig["IOType"] != "io_serial":
-                n_subout = int(MAXMULT/layer['n_in'])
-                n_totout = 0
-                layer['n_subout'] = []
-                layer['weights_n_subzeros'] = []
-                layer['n_part'] = 0
-                while n_totout < layer['n_out']:
-                    if n_totout + n_subout <= layer['n_out']:
-                        layer['n_subout'].append(n_subout)
-                        n_totout += n_subout                    
-                    else:
-                        layer['n_subout'].append(layer['n_out']-n_totout)
-                        n_totout += layer['n_out']-n_totout
-                    layer['n_part'] += 1
-                for i_part in range(0,layer['n_part']):
-                    i_subout = 0
-                    if i_part>0:
-                        i_subout = sum(layer['n_subout'][0:i_part])
-                    cur_n_zeros = print_array_to_cpp("w{}".format(layer_counter), weights, yamlConfig['OutputDir'], quantize, i_part, layer['n_part'], i_subout, layer['n_subout'][i_part])
-                    print_array_to_cpp("b{}".format(layer_counter), biases, yamlConfig['OutputDir'], i_part, layer['n_part'], i_subout, layer['n_subout'][i_part])
-                    layer['weights_n_subzeros'].append(cur_n_zeros)
-            
+        if layer['class_name'] == 'InputLayer':
+            layer['input_shape'] = keras_layer['config']['batch_input_shape'][1:]
+        if 'Dense' in layer['class_name']:
+            weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
+            layer['n_in'] = weights_shape[0]
+            layer['n_out'] = weights_shape[1]
+            if 'Binary' in layer['class_name']:
+                layer['quantize'] = 2
+            elif 'Ternary' in layer['class_name']:
+                layer['quantize'] = 3
+            else:
+                layer['quantize'] = 0
             current_shape = [current_shape[0], layer['n_out']]
         elif layer['class_name']=='Conv1D':
-            # weights.shape = (filter_width, n_channels, n_filters)
+            # weights_shape = (filter_width, n_channels, n_filters)
+            weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
             layer['y_in']=current_shape[1]
-            layer['y_filt']=weights.shape[0] # or keras_layer['config']['kernel_size']
-            layer['n_chan']=weights.shape[1] 
-            layer['n_filt']=weights.shape[2] # or keras_layer['config']['filters']
+            layer['y_filt']=weights_shape[0] # or keras_layer['config']['kernel_size']
+            layer['n_chan']=weights_shape[1]
+            layer['n_filt']=weights_shape[2] # or keras_layer['config']['filters']
             layer['stride']=keras_layer['config']['strides'][0]
             layer['padding']=keras_layer['config']['padding']
             if layer['padding']=='same':
@@ -235,12 +200,14 @@ def main():
                 layer['pad_right'] = 0
             current_shape=[current_shape[0], layer['y_out'], layer['n_filt']]
         elif layer['class_name']=='Conv2D':
+            # weights_shape = (filter_height, filter_width, n_channels, n_filters)
+            weights_shape = get_weights_shape(yamlConfig['KerasH5'], layer['name'])
             layer['in_height']=current_shape[1]
             layer['in_width']=current_shape[2]
-            layer['filt_height']=weights.shape[0]
-            layer['filt_width']=weights.shape[1]
-            layer['n_chan']=weights.shape[2]
-            layer['n_filt']=weights.shape[3]
+            layer['filt_height']=weights_shape[0]
+            layer['filt_width']=weights_shape[1]
+            layer['n_chan']=weights_shape[2]
+            layer['n_filt']=weights_shape[3]
             layer['stride_height']=keras_layer['config']['strides'][0]
             layer['stride_width']=keras_layer['config']['strides'][1]
             layer['padding']=keras_layer['config']['padding']
@@ -274,18 +241,17 @@ def main():
                 layer['pad_right'] = 0
             current_shape=[current_shape[0], layer['out_height'], layer['out_width'], layer['n_filt']]
         elif layer['class_name']=='BatchNormalization':
-            if is_dense:
-                layer['n_in']=mean.shape[0]
-                layer['n_out']=mean.shape[0]
+            in_size = 1
+            for dim in current_shape[1:]:
+                in_size *= dim
+            layer['n_in'] = in_size
+            layer['n_out'] = layer['n_in']
+            if len(current_shape) == 2:
                 layer['n_filt'] = -1
-                current_shape = [current_shape[0], layer['n_out']]
-            elif is_conv2d:
-                layer['n_in']=current_shape[1]*current_shape[2]*current_shape[3] 
-                layer['n_out']=layer['n_in']
-                layer['in_height']=current_shape[1]
-                layer['in_width']=current_shape[2]
+            elif len(current_shape) == 3:
+                layer['n_filt']=current_shape[2]
+            elif len(current_shape) == 4:
                 layer['n_filt']=current_shape[3]
-                current_shape=[current_shape[0], layer['in_height'], layer['in_width'], layer['n_filt']]
         elif 'Pooling' in layer['class_name']:
             info = layer['class_name'].split('Pooling')
             d = int(info[1].split('D')[0])
@@ -296,7 +262,7 @@ def main():
             elif d == 2:
                 layer['in_height']=current_shape[1]
                 layer['in_width']=current_shape[2]
-                layer['n_filt']=layer_list[-1]['n_filt']
+                layer['n_filt']=current_shape[3]
                 layer['stride_height']=keras_layer['config']['strides'][0]
                 layer['stride_width']=keras_layer['config']['strides'][1]
                 layer['pool_height']=keras_layer['config']['pool_size'][0]
@@ -331,67 +297,45 @@ def main():
                 layer['pad_bottom'] = 0
                 layer['pad_left'] = 0
                 layer['pad_right'] = 0
-                layer['n_out'] = layer['out_height'] * layer['out_height'] * layer['n_filt'] 
+                layer['n_out'] = layer['out_height'] * layer['out_height'] * layer['n_filt']
             current_shape=[current_shape[0], layer['out_height'], layer['out_width'], layer['n_filt']]
 
-        elif layer['class_name']=='Activation':
-            if layer_list[-1]['class_name'] != 'BatchNormalization':
-                layer_list[-1]['activation'] = layer['activation']
-                skip_layer = True
-                layer_counter = layer_counter - 1
         elif layer['class_name']=='LeakyReLU':
-            if layer_list[-1]['class_name'] != 'BatchNormalization':
-                layer_list[-1]['activation'] = layer['class_name']
-                layer_list[-1]['activ_param'] = keras_layer["config"].get('alpha', 0.3)
-                skip_layer = True
-                layer_counter = layer_counter - 1
-            else:
-                layer['activation'] = layer['class_name']
-                layer['activ_param'] = keras_layer["config"].get('alpha', 0.3)
+            layer['activation'] = layer['class_name']
+            layer['activ_param'] = keras_layer["config"].get('alpha', 0.3)
         elif layer['class_name']=='ThresholdedReLU':
-            if layer_list[-1]['class_name'] != 'BatchNormalization':
-                layer_list[-1]['activation'] = layer['class_name']
-                layer_list[-1]['activ_param'] = keras_layer["config"].get('theta', 1.)
-                skip_layer = True
-                layer_counter = layer_counter - 1
-            else:
-                layer['activation'] = layer['class_name']
-                layer['activ_param'] = keras_layer["config"].get('theta', 1.)
+            layer['activation'] = layer['class_name']
+            layer['activ_param'] = keras_layer["config"].get('theta', 1.)
         elif layer['class_name']=='ELU':
-            if layer_list[-1]['class_name'] != 'BatchNormalization':
-                layer_list[-1]['activation'] = layer['class_name']
-                layer_list[-1]['activ_param'] = keras_layer["config"].get('alpha', 1.)
-                skip_layer = True
-                layer_counter = layer_counter - 1
-            else:
-                layer['activation'] = layer['class_name']
-                layer['activ_param'] = keras_layer["config"].get('alpha', 1.)
+            layer['activation'] = layer['class_name']
+            layer['activ_param'] = keras_layer["config"].get('alpha', 1.)
         elif layer['class_name']=='PReLU':
-            if layer_list[-1]['class_name'] != 'BatchNormalization':
-                layer_list[-1]['activation'] = layer['class_name']
-                skip_layer = True
-                layer_counter = layer_counter - 1
-            else:
-                layer['activation'] = layer['class_name']
-            
-            #Translate learned alpha array from h5 file
-            weights = h5File['/{}/{}/alpha:0'.format(layer['name'],layer['name'])][()]
-            print_array_to_cpp("a{}".format(layer_counter), weights, yamlConfig['OutputDir'])
+            layer['activation'] = layer['class_name']
 
-        if not skip_layer:
-            print('Layer name: {}, layer type: {}, current shape: {}, number of zeros: {}'.format(layer['name'], layer['class_name'], current_shape, cur_n_zeros))
-            if layer['n_part'] > 1: 
-                print(' -> layer will be divided into {} sublayer calls; output neurons: {} '.format(layer['n_part'], layer['n_subout']))
-            layer_list.append( layer )
+        print('Layer name: {}, layer type: {}, current shape: {}'.format(layer['name'], layer['class_name'], current_shape))
+        layer_list.append( layer )
+        if 'activation' in layer and layer['class_name'] not in activation_layers:
+            act_layer = {}
+            act_layer['name'] = layer['name'] + '_' + layer['activation']
+            act_layer['activation'] = layer['activation']
+            if 'activ_param' in layer:
+                act_layer['activ_param'] = layer['activ_param']
+                act_layer['class_name'] = layer['activation']
+            else:
+                act_layer['class_name'] = 'Activation'
+            inputs_map[layer['name']] = act_layer['name']
+            if output_layers is not None and layer['name'] in output_layers:
+                output_layers = [act_layer['name'] if name == layer['name'] else name for name in output_layers]
+            layer_list.append(act_layer)
 
 
     #################
     ## Generate HLS
     #################
 
-    #Weights and biases are already dumped to output directory
-    #Now generate HLS from list of layer dictionaries
-    hls_writer(layer_list, yamlConfig)
+    reader = KerasDataReader(yamlConfig)
+    hls_model = HLSModel(yamlConfig, reader, layer_list, input_layers, output_layers)
+    write_hls(hls_model)
 
 
 if __name__ == "__main__":

--- a/nnet_utils/nnet_batchnorm.h
+++ b/nnet_utils/nnet_batchnorm.h
@@ -51,28 +51,29 @@ void normalize(
     res_T     res[CONFIG_T::n_in],
     typename CONFIG_T::scale_t  scale[CONFIG_T::n_in],
     typename CONFIG_T::beta_t   beta[CONFIG_T::n_in],
-    typename CONFIG_T::mean_t   mean[CONFIG_T::n_in])
+    typename CONFIG_T::mean_t   mean[CONFIG_T::n_in]
+)
 {
     data_T cache;
    
     // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=scale,beta,mean
 
-    if (CONFIG_T::io_type == io_parallel){
+    if (CONFIG_T::io_type == io_parallel) {
         // For parallel inputs:
         //   - completely partition arrays -- target fabric
         //   - if we have an unroll factor, limit number of multipliers
         #pragma HLS PIPELINE II=CONFIG_T::reuse_factor
 
         // #pragma HLS ARRAY_PARTITION variable=weights complete // remove this line for now, it breaks compression sometimes
-	#pragma HLS ARRAY_PARTITION variable=scale complete
+        #pragma HLS ARRAY_PARTITION variable=scale complete
         #pragma HLS ARRAY_PARTITION variable=beta complete
-	#pragma HLS ARRAY_PARTITION variable=mean complete
+        #pragma HLS ARRAY_PARTITION variable=mean complete
 
         int multiplier_limit  = ceil(float(CONFIG_T::n_in*CONFIG_T::n_in) / float(CONFIG_T::reuse_factor));
         #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
 
-    } else if (CONFIG_T::io_type == io_serial){
+    } else if (CONFIG_T::io_type == io_serial) {
         #pragma HLS ARRAY_RESHAPE variable=scale complete dim=1
         #pragma HLS ARRAY_RESHAPE variable=beta complete dim=1
         #pragma HLS ARRAY_RESHAPE variable=mean complete dim=1
@@ -80,18 +81,19 @@ void normalize(
     }            
 
     // Calcuate result
-    Result: for(int ires = 0; ires < CONFIG_T::n_in; ires++){
+    Result: for (int ires = 0; ires < CONFIG_T::n_in; ires++) {
         if (CONFIG_T::io_type == io_serial){
             #pragma HLS UNROLL
             #pragma HLS PIPELINE
         }
-        if(CONFIG_T::n_filt==-1) res[ires] = (data[ires]-mean[ires])*scale[ires]+beta[ires];
-	else{
-	 int norm_index = ires%CONFIG_T::n_filt;
-	 res[ires] = (data[ires]-mean[norm_index])*scale[norm_index]+beta[norm_index];
+        
+        if (CONFIG_T::n_filt==-1) {
+            res[ires] = (data[ires]-mean[ires])*scale[ires]+beta[ires];
+	    } else {
+            int norm_index = ires%CONFIG_T::n_filt;
+            res[ires] = (data[ires]-mean[norm_index])*scale[norm_index]+beta[norm_index];
+        }
 	}
-    }   
-       
 }
 
 }

--- a/nnet_utils/nnet_conv.h
+++ b/nnet_utils/nnet_conv.h
@@ -25,9 +25,9 @@
 
 namespace nnet {
 
-struct conv_config
+struct conv1d_config
 {
-    // Internal data type definitions                                                                                      
+    // Internal data type definitions
     typedef float bias_t;
     typedef float weight_t;
     typedef float accum_t;
@@ -40,8 +40,8 @@ struct conv_config
     static const unsigned y_filt = 10;
     static const unsigned n_filt = 4;
     static const unsigned stride = 1;
-    static const unsigned y_out = 128; 
-  
+    static const unsigned y_out = 128;
+
     static const unsigned reuse_factor = 1;
     static const bool store_weights_in_bram = false;
     static const unsigned n_zeros = 0; // not used yet
@@ -58,37 +58,37 @@ int compute_multiplier_limit(
     int n_mult = 0;
     for(int ii = 0; ii < CONFIG_T::y_out; ii++) {
         for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-	    for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
+            for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
                 for(int jj = 0; jj < CONFIG_T::y_filt; jj++){
-                    
+
                     int index_weight = jj*CONFIG_T::n_chan*CONFIG_T::n_filt + cc*CONFIG_T::n_filt + ff;
-                    
+
                     if((ii*CONFIG_T::stride+jj) < CONFIG_T::pad_left || (ii*CONFIG_T::stride+jj) >= (CONFIG_T::pad_left + CONFIG_T::y_in)){
-			//padded -- do nothing
-			continue;
-                    }
-                    else {
-			//need to tune this cut?
+                        //padded -- do nothing
+                        continue;
+                    } else {
+                        //need to tune this cut?
                         if( weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20 ){
-			    n_mult++;
-			}//end if nonzero weight
+                            n_mult++;
+                        }//end if nonzero weight
                     }//end not padding
                 }//end loop accross filter
-	    }//end channel loop
-	}//end filter loop
+            }//end channel loop
+        }//end filter loop
     }//end output loop
 
     return ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
-   
+
 }//end compute_n_mult
 
 
 template<class data_T, class res_T, typename CONFIG_T>
 void conv_1d(
-	     data_T    data[CONFIG_T::y_in][CONFIG_T::n_chan],
-	     res_T     res[CONFIG_T::y_out][CONFIG_T::n_filt],
-	     typename CONFIG_T::weight_t  weights[CONFIG_T::y_filt * CONFIG_T::n_chan * CONFIG_T::n_filt],
-	     typename CONFIG_T::bias_t    biases[CONFIG_T::n_filt])
+    data_T data[CONFIG_T::y_in * CONFIG_T::n_chan],
+    res_T  res[CONFIG_T::y_out * CONFIG_T::n_filt],
+    typename CONFIG_T::weight_t weights[CONFIG_T::y_filt * CONFIG_T::n_chan * CONFIG_T::n_filt],
+    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt]
+)
 {
 
     typename CONFIG_T::accum_t mult[CONFIG_T::y_out * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::y_filt];
@@ -96,74 +96,75 @@ void conv_1d(
 
     #pragma HLS ARRAY_PARTITION variable=mult complete dim=0
     #pragma HLS ARRAY_PARTITION variable=acc complete dim=0
-    
-    // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases 
+
+    // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=weights,biases
-    
+
     // Parallel mode
     #pragma HLS PIPELINE
     #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
-  
+
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit<CONFIG_T>(weights);
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
-    
+
     // Convolve, saving all multiplication results to accumulate later
     ConvOut: for(int ii = 0; ii < CONFIG_T::y_out; ii++) {
         ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
             ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
                 ConvMult: for(int jj = 0; jj < CONFIG_T::y_filt; jj++){
-                    
+
                     int index_mult   = ii*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::y_filt + ff*CONFIG_T::n_chan*CONFIG_T::y_filt + cc*CONFIG_T::y_filt + jj;
                     int index_weight = jj*CONFIG_T::n_chan*CONFIG_T::n_filt + cc*CONFIG_T::n_filt + ff;
-                    
+                    int index_data   = (ii*CONFIG_T::stride+jj-CONFIG_T::pad_left) * CONFIG_T::n_chan + cc;
+
                     if((ii*CONFIG_T::stride+jj) < CONFIG_T::pad_left || (ii*CONFIG_T::stride+jj) >= (CONFIG_T::pad_left + CONFIG_T::y_in)){
                         mult[index_mult] = 0;
                     }
                     else {
-                        mult[index_mult] = data[ii*CONFIG_T::stride+jj-CONFIG_T::pad_left][cc] * weights[index_weight];
+                        mult[index_mult] = data[index_data] * weights[index_weight];
                     }
                 }
-	    	}//end channel loop
-		}//end filter loop
+            }//end channel loop
+        }//end filter loop
     }//end output loop
 
 
     // Initialize accumulator with input biases
     for(int ii = 0; ii < CONFIG_T::y_out; ii++) {
-		for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-	    	acc[ii][ff]=biases[ff];
-		}
+        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            acc[ii][ff]=biases[ff];
+        }
     }
 
-    
+
     // Accumulate multiplication result
     AccumOut: for(int ii = 0; ii < CONFIG_T::y_out; ii++) {
         AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-			//Do "dot product" sum within filter and sum over channels
+            //Do "dot product" sum within filter and sum over channels
             AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-			    AccumDot: for(int jj = 0; jj < CONFIG_T::y_filt; jj++){
+                AccumDot: for(int jj = 0; jj < CONFIG_T::y_filt; jj++){
                     int index_mult = ii*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::y_filt + ff*CONFIG_T::n_chan*CONFIG_T::y_filt + cc*CONFIG_T::y_filt + jj;
-		    		acc[ii][ff] += mult[index_mult];
+                    acc[ii][ff] += mult[index_mult];
                 }//end dot product loop
-	    	}//end channel loop
-		}//end filter loop
+            }//end channel loop
+        }//end filter loop
     }//end output loop
 
-    
-     // Cast to "res_t" type 
+
+    // Cast to "res_t" type
     for(int ii = 0; ii < CONFIG_T::y_out; ii++) {
-		for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-	    	res[ii][ff] = (res_T)(acc[ii][ff]);
-		}
+        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+            res[ii * CONFIG_T::n_filt + ff] = (res_T)(acc[ii][ff]);
+        }
     }
 }
 
 
 template<class data_T, int NROWS, int NCOLS>
     void flatten(
-        data_T    data[NROWS][NCOLS], 
-	data_T     res[NROWS*NCOLS])
+        data_T    data[NROWS][NCOLS],
+    data_T     res[NROWS*NCOLS])
 {
 
     //Initialize
@@ -181,8 +182,8 @@ template<class data_T, int NROWS, int NCOLS>
 
 template<class data_T, int NROWS, int NCOLS>
     void unflatten(
-        data_T    data[NROWS*NCOLS], 
-	data_T     res[NROWS][NCOLS])
+        data_T    data[NROWS*NCOLS],
+    data_T     res[NROWS][NCOLS])
 {
     for(int r=0; r<NROWS; r++){
         for(int c=0; c<NCOLS; c++){
@@ -190,8 +191,6 @@ template<class data_T, int NROWS, int NCOLS>
         }
     }
 }
-
-
 
 
 }//end namespace

--- a/nnet_utils/nnet_conv2d.h
+++ b/nnet_utils/nnet_conv2d.h
@@ -27,7 +27,7 @@ namespace nnet {
 
 struct conv2d_config
 {
-    // Internal data type definitions                                                                                      
+    // Internal data type definitions
     typedef float bias_t;
     typedef float weight_t;
     typedef float accum_t;
@@ -45,9 +45,9 @@ struct conv2d_config
     static const unsigned n_filt = 4;
     static const unsigned stride_height = 1;
     static const unsigned stride_width = 1;
-    static const unsigned out_height = 128; 
-    static const unsigned out_width = 128; 
-  
+    static const unsigned out_height = 128;
+    static const unsigned out_width = 128;
+
     static const unsigned reuse_factor = 1;
     static const bool store_weights_in_bram = false;
     static const unsigned n_zeros = 0; // not used yet
@@ -58,200 +58,193 @@ struct conv2d_config
 //This function should not be synthesized into firmware
 template<typename CONFIG_T>
     int compute_multiplier_limit_conv2d(
-	typename CONFIG_T::weight_t  weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt]
-	)
+    typename CONFIG_T::weight_t  weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt]
+)
 {
     int n_mult = 0;
 
     for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-      for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-          for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-            for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-              for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
-                    
-		int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
-                		 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
-            		         + cc*CONFIG_T::n_filt
-         		         + ff;
+        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
+                for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
+                    for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
+                        for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
 
-		if( (oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height) 
-          	 || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
-		    //padded - do nothing
-		    continue;
-                }
-		else {
-		    if( weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20 ){
-			n_mult++;
-		     }
-		}
+                                int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
+                                                 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
+                                                 + cc*CONFIG_T::n_filt
+                                                  + ff;
 
-              }//end mult loop
-            }//end channel loop
-	  }//end filter width loop
-        }//end filter height loop      
-      }//end output width loop
+                                if ((oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top
+                                || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
+                                || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left
+                                || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
+                                    //padded - do nothing
+                                    continue;
+                                } else {
+                                    if (weights[index_weight] > 1e-20 || weights[index_weight] < -1e-20) {
+                                          n_mult++;
+                                    }
+                                }
+
+                        }//end mult loop
+                    }//end channel loop
+                }//end filter width loop
+            }//end filter height loop
+        }//end output width loop
     }//end output height loop
 
     return ceil( float(n_mult) / float(CONFIG_T::reuse_factor) );
 
-}//end compute_n_mult 
+}//end compute_n_mult
 
 
 template<class data_T, class res_T, typename CONFIG_T>
 void conv_2d(
-             data_T   data[CONFIG_T::in_height][CONFIG_T::in_width][CONFIG_T::n_chan],
-	     res_T    res[CONFIG_T::out_height][CONFIG_T::out_width][CONFIG_T::n_filt],
-	     typename CONFIG_T::weight_t  weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
-	     typename CONFIG_T::bias_t    biases[CONFIG_T::n_filt])
+    data_T data[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan],
+    res_T  res[CONFIG_T::out_height*CONFIG_T::out_width*CONFIG_T::n_filt],
+    typename CONFIG_T::weight_t weights[CONFIG_T::filt_height * CONFIG_T::filt_width * CONFIG_T::n_chan * CONFIG_T::n_filt],
+    typename CONFIG_T::bias_t   biases[CONFIG_T::n_filt])
 {
 
-  
-    //Convert data to 1D
-    data_T data_1d[CONFIG_T::in_height*CONFIG_T::in_width*CONFIG_T::n_chan];
-    #pragma HLS ARRAY_PARTITION variable=data_1d complete dim=0
-    for(int ih = 0; ih < CONFIG_T::in_height; ih++) {
-      for(int iw = 0; iw < CONFIG_T::in_width; iw++) {
-	for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-          data_1d[ih*CONFIG_T::in_width*CONFIG_T::n_chan + iw*CONFIG_T::n_chan + cc] = data[ih][iw][cc];
-        }
-      }
-    }
-  
-	  
     typename CONFIG_T::accum_t mult[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt * CONFIG_T::n_chan * CONFIG_T::filt_height * CONFIG_T::filt_width];
     typename CONFIG_T::accum_t acc[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt];
 
     #pragma HLS ARRAY_PARTITION variable=mult complete dim=0
     #pragma HLS ARRAY_PARTITION variable=acc complete dim=0
-    
-    // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases 
+
+    // Use a function_instantiate in case it helps to explicitly optimize unchanging weights/biases
     #pragma HLS function_instantiate variable=weights,biases
-    
+
     // Parallel mode
     #pragma HLS PIPELINE
     #pragma HLS ARRAY_PARTITION variable=biases complete dim=0
-  
+
     // Limit multipliers to control parallelization
     const int multiplier_limit = compute_multiplier_limit_conv2d<CONFIG_T>(weights);
     #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
-    
+
     // Convolve, saving all multiplication results to accumulate later
     ConvOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-      ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-        ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
-          ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-            ConvFiltHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-              ConvFiltWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
-                    
-                int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width 
-                               + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width 
-               		       + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-              		       + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                               + fh*CONFIG_T::filt_width 
- 		               + fw;
-                                 
-		int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
-                		 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
-            		         + cc*CONFIG_T::n_filt
-         		         + ff;
+        ConvOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            ConvFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++){
+                ConvChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
+                    ConvFiltHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
+                        ConvFiltWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
 
-		if( (oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height) 
-          	 || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) 
-		{
-                  mult[index_mult] = 0;
-                }
-		else {
-		    mult[index_mult] = data_1d  [ (oh*CONFIG_T::stride_height+fh-CONFIG_T::pad_top)*CONFIG_T::in_width*CONFIG_T::n_chan
-						+(ow*CONFIG_T::stride_width+fw-CONFIG_T::pad_left)*CONFIG_T::n_chan
-                                                +cc ] * weights[index_weight];
-                }
+                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                                + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                               + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                           + fh*CONFIG_T::filt_width
+                                                + fw;
 
-              }//end mult loop
-            }//end channel loop
-	  }//end filter width loop
-        }//end filter height loop      
-      }//end output width loop
+                                int index_weight = fh*CONFIG_T::filt_width*CONFIG_T::n_chan*CONFIG_T::n_filt
+                                                 + fw*CONFIG_T::n_chan*CONFIG_T::n_filt
+                                                 + cc*CONFIG_T::n_filt
+                                                  + ff;
+
+                                if ((oh*CONFIG_T::stride_height+fh) < CONFIG_T::pad_top
+                                || (oh*CONFIG_T::stride_height+fh) >= (CONFIG_T::pad_top+CONFIG_T::in_height)
+                                || (ow*CONFIG_T::stride_width+fw) < CONFIG_T::pad_left
+                                || (ow*CONFIG_T::stride_width+fw) >= (CONFIG_T::pad_left+CONFIG_T::in_width)) {
+                                    mult[index_mult] = 0;
+                                } else {
+                                    int index_data = (oh*CONFIG_T::stride_height+fh-CONFIG_T::pad_top)*CONFIG_T::in_width*CONFIG_T::n_chan
+                                                   + (ow*CONFIG_T::stride_width+fw-CONFIG_T::pad_left)*CONFIG_T::n_chan
+                                                   + cc;
+                                    mult[index_mult] = data[index_data] * weights[index_weight];
+                                }
+
+                        }//end mult loop
+                    }//end channel loop
+                  }//end filter width loop
+            }//end filter height loop
+        }//end output width loop
     }//end output height loop
 
 
     // Initialize accumulator with input biases
     for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-      for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-        for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-          acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]=biases[ff];
+            }
         }
-      }
     }
 
-    
+
     // Accumulate multiplication result
     AccumOutHeight: for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-      AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-        AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
-	  //Do "dot product" sum within filter and sum over channels
-          AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
-            AccumDotHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
-              AccumDotWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
+        AccumOutWidth: for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+            AccumFilt: for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                //Do "dot product" sum within filter and sum over channels
+                AccumChan: for(int cc = 0; cc < CONFIG_T::n_chan; cc++){
+                    AccumDotHeight: for(int fh = 0; fh < CONFIG_T::filt_height; fh++){
+                        AccumDotWidth: for(int fw = 0; fw < CONFIG_T::filt_width; fw++){
 
-                int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width 
-                               + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width 
-               		       + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
-              		       + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
-                               + fh*CONFIG_T::filt_width 
- 		               + fw;
-		
-		acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff] += mult[index_mult];
-                
-              }//end dot product filter width loop
-            }//end dot product filter height loop
-	  }//end n channel loop
-	}//end n filter loop
-      }//end output width loop
+                            int index_mult = oh*CONFIG_T::out_width*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                           + ow*CONFIG_T::n_filt*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                                + ff*CONFIG_T::n_chan*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                               + cc*CONFIG_T::filt_height*CONFIG_T::filt_width
+                                           + fh*CONFIG_T::filt_width
+                                                + fw;
+                            int index_acc = oh*CONFIG_T::out_width*CONFIG_T::n_filt
+                                          + ow*CONFIG_T::n_filt
+                                          + ff;
+
+                            acc[index_acc] += mult[index_mult];
+
+                        }//end dot product filter width loop
+                    }//end dot product filter height loop
+                }//end n channel loop
+            }//end n filter loop
+        }//end output width loop
     }//end output height loop
-    
-     // Cast to "res_t" type 
+
+     // Cast to "res_t" type
     for(int oh = 0; oh < CONFIG_T::out_height; oh++) {
-      for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
-	for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
- 	  res[oh][ow][ff] = (res_T)(acc[oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff]);
-	}
-      }
+        for(int ow = 0; ow < CONFIG_T::out_width; ow++) {
+              for(int ff = 0; ff < CONFIG_T::n_filt; ff++) {
+                int index = oh*CONFIG_T::out_width*CONFIG_T::n_filt + ow*CONFIG_T::n_filt + ff;
+                res[index] = (res_T)(acc[index]);
+            }
+        }
     }
 
 }//end conv2d
 
 
 template<class data_T, int N1, int N2, int N3>
-    void flatten(
-        data_T    data[N1][N2][N3], 
-	data_T     res[N1*N2*N3])
+void flatten(
+    data_T data[N1][N2][N3],
+    data_T res[N1*N2*N3]
+)
 {
     for(int i1=0; i1<N1; i1++){
-      for(int i2=0; i2<N2; i2++){
-        for(int i3=0; i3<N3; i3++){
-            res[i1*N2*N3+i2*N3+i3] = data[i1][i2][i3];
-        }//i3
-      }//i2
+        for(int i2=0; i2<N2; i2++){
+            for(int i3=0; i3<N3; i3++){
+                res[i1*N2*N3+i2*N3+i3] = data[i1][i2][i3];
+            }//i3
+        }//i2
     }//i1
 }
 
 
 template<class data_T, int N1, int N2, int N3>
-    void unflatten(
-        data_T    data[N1*N2*N3], 
-	data_T     res[N1][N2][N3])
+void unflatten(
+    data_T data[N1*N2*N3],
+    data_T res[N1][N2][N3]
+)
 {
     for(int i1=0; i1<N1; i1++){
-      for(int i2=0; i2<N2; i2++){
-        for(int i3=0; i3<N3; i3++){
-	    res[i1][i2][i3] = data[i1*N2*N3+i2*N3+i3];
-        }//i3
-      }//i2
-    }//i1  
+        for(int i2=0; i2<N2; i2++){
+            for(int i3=0; i3<N3; i3++){
+                res[i1][i2][i3] = data[i1*N2*N3+i2*N3+i3];
+            }//i3
+        }//i2
+    }//i1
 }
-
-
 
 
 }//end namespace

--- a/nnet_utils/nnet_dense.h
+++ b/nnet_utils/nnet_dense.h
@@ -26,7 +26,7 @@
 
 namespace nnet {
 
-struct layer_config
+struct dense_config
 {
     // Internal data type definitions
     typedef float bias_t;
@@ -46,7 +46,7 @@ struct layer_config
 };
 
  template<class data_T, class res_T, typename CONFIG_T>
-void compute_layer(
+void dense(
     data_T    data[CONFIG_T::n_in],
     res_T     res[CONFIG_T::n_out],
     typename CONFIG_T::weight_t  weights[CONFIG_T::n_in*CONFIG_T::n_out],
@@ -92,7 +92,7 @@ void compute_layer(
             #pragma HLS RESOURCE variable=weights core=ROM_2P_BRAM
         }
     }
-    
+
     // Do the matrix-multiply
     Product1: for(int ii = 0; ii < CONFIG_T::n_in; ii++) {
         if (CONFIG_T::io_type == io_serial){
@@ -104,8 +104,8 @@ void compute_layer(
                 int multiplier_limit  = ceil(float(CONFIG_T::n_out) / float(CONFIG_T::reuse_factor));
                 #pragma HLS ALLOCATION instances=mul limit=multiplier_limit operation
             }
-	    int index = ii*CONFIG_T::n_out+jj;
-	    mult[index] = cache * weights[index];
+        int index = ii*CONFIG_T::n_out+jj;
+        mult[index] = cache * weights[index];
         }
     }
 
@@ -123,8 +123,8 @@ void compute_layer(
             #pragma HLS PIPELINE
         }
         Accum2: for(int jj = 0; jj < CONFIG_T::n_out; jj++) {
-	    int index = ii*CONFIG_T::n_out+jj;
-	    acc[jj] += mult[index];
+        int index = ii*CONFIG_T::n_out+jj;
+        acc[jj] += mult[index];
         }
     }
 
@@ -134,7 +134,7 @@ void compute_layer(
             #pragma HLS UNROLL
         }
         res[ires] = (res_T) (acc[ires]);
-    }    
+    }
 }
 
 }

--- a/nnet_utils/nnet_dense.h
+++ b/nnet_utils/nnet_dense.h
@@ -17,8 +17,8 @@
 //    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#ifndef NNET_LAYER_H_
-#define NNET_LAYER_H_
+#ifndef NNET_DENSE_H_
+#define NNET_DENSE_H_
 
 #include "nnet_common.h"
 #include "hls_stream.h"

--- a/nnet_utils/nnet_merge.h
+++ b/nnet_utils/nnet_merge.h
@@ -42,15 +42,6 @@ struct concat_config {
     static const unsigned axis = -1;
 };
 
-// This approach has issues when synthetising
-/*struct concat_config {
-    static const unsigned rank = 3;
-    static constexpr unsigned n_elem1[rank] = {0};
-    static constexpr unsigned n_elem2[rank] = {0};
-
-    static const unsigned axis = -1;
-};*/
-
 template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
 void add(
     input1_T data1[CONFIG_T::n_elem],

--- a/nnet_utils/nnet_merge.h
+++ b/nnet_utils/nnet_merge.h
@@ -1,0 +1,271 @@
+//
+//    rfnoc-hls-neuralnet: Vivado HLS code for neural-net building blocks
+//
+//    Copyright (C) 2017 EJ Kreinar
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifndef NNET_MERGE_H_
+#define NNET_MERGE_H_
+
+#include "nnet_common.h"
+#include "hls_stream.h"
+#include <math.h>
+
+namespace nnet {
+
+struct merge_config
+{
+    static const unsigned n_elem = 10;
+};
+
+struct concat_config {
+    static const unsigned n_elem1_0 = 10;
+    static const unsigned n_elem1_1 = 10;
+    static const unsigned n_elem1_2 = 10;
+    static const unsigned n_elem2_0 = 10;
+    static const unsigned n_elem2_1 = 10;
+    static const unsigned n_elem2_2 = 10;
+
+    static const unsigned axis = -1;
+};
+
+// This approach has issues when synthetising
+/*struct concat_config {
+    static const unsigned rank = 3;
+    static constexpr unsigned n_elem1[rank] = {0};
+    static constexpr unsigned n_elem2[rank] = {0};
+
+    static const unsigned axis = -1;
+};*/
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void add(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = data1[ii] + data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void subtract(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = data1[ii] - data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void multiply(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = data1[ii] * data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void average(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = data1[ii] * data2[ii] / (res_T) 2;
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void maximum(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = (data1[ii] > data2[ii]) ? data1[ii] : data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void minimum(
+    input1_T data1[CONFIG_T::n_elem],
+	input2_T data2[CONFIG_T::n_elem],
+    res_T res[CONFIG_T::n_elem])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem; ii++) {
+        res[ii] = (data1[ii] < data2[ii]) ? data1[ii] : data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate1d(
+    input1_T data1[CONFIG_T::n_elem1_0], 
+	input2_T data2[CONFIG_T::n_elem2_0],
+    res_T res[CONFIG_T::n_elem1_0 + CONFIG_T::n_elem2_0])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
+        res[ii] = data1[ii];
+    }
+    for (int ii=0; ii<CONFIG_T::n_elem2_0; ii++) {
+        res[CONFIG_T::n_elem1_0 + ii] = data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_0(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1], 
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1; ii++) {
+        res[ii] = data1[ii];
+    }
+    for (int ii=0; ii<CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1; ii++) {
+        res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + ii] = data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d_1(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1], 
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
+        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
+            res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + jj] = data1[ii * CONFIG_T::n_elem1_1 + jj];
+        }
+        for (int jj=0; jj<CONFIG_T::n_elem2_1; jj++) {
+            res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] = data2[ii * CONFIG_T::n_elem2_1 + jj];
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate2d(
+    input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1], 
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1])
+{
+    if (CONFIG_T::axis == 1 || CONFIG_T::axis == -1) {
+        concatenate2d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate2d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_0(
+input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2],
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2; ii++) {
+        res[ii] = data1[ii];
+    }
+    for (int ii=0; ii<CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2; ii++) {
+        res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + ii] = data2[ii];
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_1(
+input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2], 
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
+        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
+            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
+                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2
+                            + jj * CONFIG_T::n_elem1_2
+                            + kk;
+                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2
+                             + jj * CONFIG_T::n_elem1_2
+                             + kk;
+                res[res_idx] = data1[data_idx];
+            }
+        }
+        for (int jj=0; jj<CONFIG_T::n_elem2_1; jj++) {
+            for (int kk=0; kk<CONFIG_T::n_elem2_2; kk++) {
+                int res_idx = ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) * CONFIG_T::n_elem1_2
+                            + (jj + CONFIG_T::n_elem1_1) * CONFIG_T::n_elem1_2
+                            + kk;
+                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2
+                             + jj * CONFIG_T::n_elem2_2
+                             + kk;
+                res[res_idx] = data2[data_idx];
+            }
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d_2(
+input1_T data1[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2], 
+	input2_T data2[CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1_0 * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_0 * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+{
+    for (int ii=0; ii<CONFIG_T::n_elem1_0; ii++) {
+        for (int jj=0; jj<CONFIG_T::n_elem1_1; jj++) {
+            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
+                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
+                            + jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
+                            + kk;
+                int data_idx = ii * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2
+                             + jj * CONFIG_T::n_elem1_2
+                             + kk;
+                res[res_idx] = data1[data_idx];
+            }
+            for (int kk=0; kk<CONFIG_T::n_elem1_2; kk++) {
+                res[ii * (CONFIG_T::n_elem1_1 + CONFIG_T::n_elem2_1) + CONFIG_T::n_elem1_1 + jj] = data1[ii * CONFIG_T::n_elem2_1 + jj];
+                int res_idx = ii * CONFIG_T::n_elem1_1 * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
+                            + jj * (CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2_2)
+                            + kk + CONFIG_T::n_elem1_2;
+                int data_idx = ii * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2
+                             + jj * CONFIG_T::n_elem2_2
+                             + kk;
+                res[res_idx] = data2[data_idx];
+            }
+        }
+    }
+}
+
+template<class input1_T, class input2_T, class res_T, typename CONFIG_T>
+void concatenate3d(
+    input1_T data1[CONFIG_T::n_elem1[0] * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2], 
+	input2_T data2[CONFIG_T::n_elem2[0] * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2],
+    res_T res[CONFIG_T::n_elem1[0] * CONFIG_T::n_elem1_1 * CONFIG_T::n_elem1_2 + CONFIG_T::n_elem2[0] * CONFIG_T::n_elem2_1 * CONFIG_T::n_elem2_2])
+{
+    if (CONFIG_T::axis == 2 || CONFIG_T::axis == -1) {
+        concatenate3d_2<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else if (CONFIG_T::axis == 1) {
+        concatenate3d_1<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    } else {
+        concatenate3d_0<input1_T, input2_T, res_T, CONFIG_T>(data1, data2, res);
+    }
+}
+
+}
+
+#endif

--- a/nnet_utils/nnet_pooling.h
+++ b/nnet_utils/nnet_pooling.h
@@ -133,8 +133,8 @@ constexpr int pool_op_limit(){
 }
 
 template<class data_T, typename CONFIG_T>
-void pooling2d(data_T data[CONFIG_T::in_height][CONFIG_T::in_width][CONFIG_T::n_filt],
-               data_T res[CONFIG_T::out_height][CONFIG_T::out_width][CONFIG_T::n_filt]){
+void pooling2d(data_T data[CONFIG_T::in_height * CONFIG_T::in_width * CONFIG_T::n_filt],
+               data_T res[CONFIG_T::out_height * CONFIG_T::out_width * CONFIG_T::n_filt]){
 
   // TODO partition the arrays according to the reuse factor
   const int limit = pool_op_limit<CONFIG_T>();
@@ -163,7 +163,7 @@ void pooling2d(data_T data[CONFIG_T::in_height][CONFIG_T::in_width][CONFIG_T::n_
               // Add padding
               pool[kk * CONFIG_T::stride_width + ll] = pad_val<data_T, CONFIG_T::pool_op>();
             }else{
-  					  pool[kk * CONFIG_T::stride_width + ll] = data[ii + kk][jj + ll][ff];
+  					  pool[kk * CONFIG_T::stride_width + ll] = data[(ii + kk) * CONFIG_T::in_width * CONFIG_T::n_filt + (jj + ll) * CONFIG_T::n_filt + ff];
               img_overlap++;
             }
 				  }
@@ -171,12 +171,12 @@ void pooling2d(data_T data[CONFIG_T::in_height][CONFIG_T::in_width][CONFIG_T::n_
 			  // do the pooling
         // TODO in the case of average pooling, need to reduce height * width to area of pool window
         // not overlapping padding region
-			  res[ii/CONFIG_T::stride_height][jj/CONFIG_T::stride_width][ff] =
+			  res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt + (jj/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] =
 					  pool_op<data_T, CONFIG_T::pool_height*CONFIG_T::pool_width, CONFIG_T::pool_op>(pool);
         // If the pool op is Average, the zero-padding needs to be removed from the results
         if(CONFIG_T::pool_op == Average){
           data_T rescale = CONFIG_T::pool_height * CONFIG_T::pool_width / img_overlap;
-          res[ii/CONFIG_T::stride_height][jj/CONFIG_T::stride_width][ff] *= rescale;
+          res[(ii/CONFIG_T::stride_height) * CONFIG_T::out_width * CONFIG_T::n_filt + (jj/CONFIG_T::stride_width)* CONFIG_T::n_filt + ff] *= rescale;
         }
 		  }
 	  }

--- a/test/keras-models.txt
+++ b/test/keras-models.txt
@@ -20,7 +20,7 @@ KERAS_3layer
 #KERAS_conv1d
 KERAS_conv1d_small
 KERAS_conv2d_model
-KERAS_dense_big
+#KERAS_dense_16x100x100x100x100x100x5
 KERAS_3layer_batch_norm
 KERAS_3layer_binary_smaller
 KERAS_3layer_ternary_small


### PR DESCRIPTION
This includes a major rewrite of most components of the translation, discussed in #120. It introduces a new object model in `hls_model.py` which will (hopefully) simplify adding support for new nets/layers. As a result, `hls_writer.py` is now a significantly simpler.

The changes include support for multiple inputs/outputs (#104), move to flattened arrays everywhere, treating of all activations as layers and I also removed sublayer support (in anticipation of a better alternative). As a result, `keras-to-hls.py` has also seen some cleanups.

I have tested it and it produces the same results in C simulation and same usage/latency numbers in synthesis.

I am sorry this is all one big changeset, but it was very hard to track all upstream changes and rebase every time, so I have mostly developed this as separate files which were then just renamed and placed over existing ones in the end.