### PR TITLE
fixed keras-to-hls.py to support newer keras versions

### DIFF
--- a/keras-to-hls/keras-to-hls.py
+++ b/keras-to-hls/keras-to-hls.py
@@ -109,6 +109,8 @@ def main():
     if model_arch['class_name'] == 'Sequential':
         print('Interpreting Sequential')
         layer_config = model_arch["config"]
+        if 'layers' in layer_config: # Newer Keras versions have 'layers' in 'config' key
+            layer_config = layer_config['layers']
         # Sequential doesn't have InputLayer
         input_layer = {}
         input_layer['name'] = 'input1'


### PR DESCRIPTION
Found differences in the model json file for different keras versions (2.0.5 vs 2.2.4). The current keras-to-hls.py supports the older version with which the json files in the example folder were created. This PR adds a simple fix to keras-to-hls.py proposed by @vloncar  to support both versions.