### PR TITLE
Vivado template restructure

### DIFF
--- a/hls4ml/templates/templates.py
+++ b/hls4ml/templates/templates.py
@@ -4,6 +4,7 @@ class Backend(object):
         self.name = name
         self.config_templates = {}
         self.function_templates = {}
+        self.include_lists = {}
 
     def get_config_template(self, kind):
         return self.config_templates.get(kind)
@@ -11,9 +12,13 @@ class Backend(object):
     def get_function_template(self, kind):
         return self.function_templates.get(kind)
 
-    def register_templates(self, name, function_template, config_template):
+    def get_include_list(self, kind):
+        return self.include_lists.get(kind, [])
+
+    def register_templates(self, name, function_template, config_template, include_list=[]):
         self.function_templates[name] = function_template
         self.config_templates[name] = config_template
+        self.include_lists[name] = include_list
 
     def register_source(self, file_name, source, destination_dir='nnet_utils'):
         raise NotImplementedError

--- a/hls4ml/templates/vivado/firmware/defines.h
+++ b/hls4ml/templates/vivado/firmware/defines.h
@@ -1,0 +1,12 @@
+#ifndef DEFINES_H_
+#define DEFINES_H_
+
+#include <complex>
+#include "ap_int.h"
+#include "ap_fixed.h"
+
+//hls-fpga-machine-learning insert numbers
+
+//hls-fpga-machine-learning insert layer-precision
+
+#endif

--- a/hls4ml/templates/vivado/firmware/myproject.cpp
+++ b/hls4ml/templates/vivado/firmware/myproject.cpp
@@ -19,8 +19,7 @@
 #include <iostream>
 
 #include "myproject.h"
-
-//hls-fpga-machine-learning insert weights
+#include "parameters.h"
 
 void myproject(
 	//hls-fpga-machine-learning insert header

--- a/hls4ml/templates/vivado/firmware/myproject.h
+++ b/hls4ml/templates/vivado/firmware/myproject.h
@@ -24,7 +24,7 @@
 #include "ap_int.h"
 #include "ap_fixed.h"
 
-#include "parameters.h"
+#include "defines.h"
 
 
 // Prototype of top level function for C-synthesis

--- a/hls4ml/templates/vivado/firmware/parameters.h
+++ b/hls4ml/templates/vivado/firmware/parameters.h
@@ -4,25 +4,11 @@
 #include <complex>
 #include "ap_int.h"
 #include "ap_fixed.h"
-#include "nnet_utils/nnet_dense.h"
-#include "nnet_utils/nnet_dense_large.h"
-#include "nnet_utils/nnet_dense_compressed.h"
-#include "nnet_utils/nnet_conv.h"
-#include "nnet_utils/nnet_conv_large.h"
-#include "nnet_utils/nnet_conv2d.h"
-#include "nnet_utils/nnet_conv2d_large.h"
-#include "nnet_utils/nnet_activation.h"
-#include "nnet_utils/nnet_common.h"
-#include "nnet_utils/nnet_batchnorm.h"
-#include "nnet_utils/nnet_pooling.h"
-#include "nnet_utils/nnet_merge.h"
-#include "nnet_utils/nnet_array.h"
-#include "nnet_utils/nnet_image.h"
+
 #include "nnet_utils/nnet_helpers.h"
-
-//hls-fpga-machine-learning insert numbers
-
-//hls-fpga-machine-learning insert layer-precision
+//hls-fpga-machine-learning insert includes
+ 
+//hls-fpga-machine-learning insert weights
 
 //hls-fpga-machine-learning insert layer-config
 

--- a/hls4ml/templates/vivado/myproject_test.cpp
+++ b/hls4ml/templates/vivado/myproject_test.cpp
@@ -18,11 +18,12 @@
 //
 #include <fstream>
 #include <iostream>
+#include <algorithm>
+#include <vector>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 
-#include "firmware/parameters.h"
 #include "firmware/myproject.h"
 
 #define CHECKPOINT 5000

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -159,23 +159,33 @@ merge_function_template = 'nnet::{merge}<{input1_t}, {input2_t}, {output_t}, {co
 resize_function_template = 'nnet::resize_{algorithm}<{input_t}, {config}>({input}, {output});'
 transpose_function_template = 'nnet::transpose{dim}<{input_t}, {config}>({input}, {output});'
 
+dense_include_list = ['nnet_utils/nnet_dense.h', 'nnet_utils/nnet_dense_compressed.h', 'nnet_utils/nnet_dense_large.h']
+batchnorm_include_list = ['nnet_utils/nnet_batchnorm.h']
+conv1d_include_list = ['nnet_utils/nnet_conv.h', 'nnet_utils/nnet_conv_large.h']
+conv2d_include_list = ['nnet_utils/nnet_conv2d.h', 'nnet_utils/nnet_conv2d_large.h']
+activ_include_list = ['nnet_utils/nnet_activation.h']
+pooling_include_list = ['nnet_utils/nnet_pooling.h']
+merge_include_list = ['nnet_utils/nnet_merge.h']
+resize_include_list = ['nnet_utils/nnet_image.h']
+transpose_include_list = ['nnet_utils/nnet_array.h']
+
 class VivadoBackend(Backend):
     def __init__(self):
         super(VivadoBackend, self).__init__('Vivado')
-        self.register_templates('Dense', dense_function_template, dense_config_template)
-        self.register_templates('BinaryDense'            , dense_function_template,       dense_config_template)
-        self.register_templates('BatchNormalization'     , batchnorm_function_template,   batchnorm_config_template)
-        self.register_templates('Conv1D'                 , conv1d_function_template,      [conv1d_config_template, conv_mult_config_template])
-        self.register_templates('Conv2D'                 , conv2d_function_template,      [conv2d_config_template, conv_mult_config_template])
-        self.register_templates('Activation'             , activ_function_template,       activ_config_template)
-        self.register_templates('ParametrizedActivation' , param_activ_function_template, activ_config_template)
-        self.register_templates('PReLU'                  , param_activ_function_template, activ_config_template)
-        self.register_templates('Pooling1D'              , pooling1d_function_template,   pooling1d_config_template)
-        self.register_templates('Pooling2D'              , pooling2d_function_template,   pooling2d_config_template)
-        self.register_templates('Merge'                  , merge_function_template,       merge_config_template)
-        self.register_templates('Concatenate'            , merge_function_template,       concat_config_template)
-        self.register_templates('Resize'                 , resize_function_template,      resize_config_template)
-        self.register_templates('Transpose'              , transpose_function_template,   transpose_config_template)
+        self.register_templates('Dense', dense_function_template, dense_config_template, dense_include_list)
+        self.register_templates('BinaryDense'            , dense_function_template,       dense_config_template, dense_include_list)
+        self.register_templates('BatchNormalization'     , batchnorm_function_template,   batchnorm_config_template, batchnorm_include_list)
+        self.register_templates('Conv1D'                 , conv1d_function_template,      [conv1d_config_template, conv_mult_config_template], conv1d_include_list)
+        self.register_templates('Conv2D'                 , conv2d_function_template,      [conv2d_config_template, conv_mult_config_template], conv2d_include_list)
+        self.register_templates('Activation'             , activ_function_template,       activ_config_template, activ_include_list)
+        self.register_templates('ParametrizedActivation' , param_activ_function_template, activ_config_template, activ_include_list)
+        self.register_templates('PReLU'                  , param_activ_function_template, activ_config_template, activ_include_list)
+        self.register_templates('Pooling1D'              , pooling1d_function_template,   pooling1d_config_template, pooling_include_list)
+        self.register_templates('Pooling2D'              , pooling2d_function_template,   pooling2d_config_template, pooling_include_list)
+        self.register_templates('Merge'                  , merge_function_template,       merge_config_template, merge_include_list)
+        self.register_templates('Concatenate'            , merge_function_template,       concat_config_template, merge_include_list)
+        self.register_templates('Resize'                 , resize_function_template,      resize_config_template, resize_include_list)
+        self.register_templates('Transpose'              , transpose_function_template,   transpose_config_template, transpose_include_list)
     
     def get_valid_reuse_factors(self, layer):
         n_in = 0

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -348,7 +348,7 @@ class VivadoWriter(Writer):
                 newline = line.replace('myproject', model.config.get_project_name())
             elif '//hls-fpga-machine-learning insert data' in line:
                 newline = line
-                newline += '      std::vector<float>::const_iterator in_begin = in.begin();\n'
+                newline += '      std::vector<float>::const_iterator in_begin = in.cbegin();\n'
                 newline += '      std::vector<float>::const_iterator in_end;\n'
                 for inp in model.get_input_variables():
                     newline += '      ' + inp.definition_cpp() + ';\n'

--- a/hls4ml/writer/vivado_writer.py
+++ b/hls4ml/writer/vivado_writer.py
@@ -58,6 +58,33 @@ class VivadoWriter(Writer):
         if not os.path.isdir("{}/firmware/weights".format(model.config.get_output_dir())):
             os.makedirs("{}/firmware/weights".format(model.config.get_output_dir()))
 
+    @staticmethod
+    def _make_array_pragma(variable):
+        config = variable.pragma
+        if type(config) is tuple:
+            mode = config[0]
+            if mode in ['partition', 'reshape']:
+                typ = config[1]
+                if typ != 'complete':
+                    factor = config[2]
+            elif mode == 'stream':
+                depth = config[1]
+        else:
+            mode = config
+            typ = 'complete'
+            factor = 0
+
+        if mode in ['partition', 'reshape']:
+            if typ == 'complete':
+                template = '#pragma HLS ARRAY_{mode} variable={name} {type} dim={dim}'
+            else:
+                template = '#pragma HLS ARRAY_{mode} variable={name} {type} factor={factor} dim={dim}'
+
+            return template.format(mode=mode.upper(), name=variable.name, type=typ, factor=factor, dim=0)
+
+        elif mode == 'stream':
+            return '#pragma HLS STREAM variable={name} depth={depth} dim={dim}'.format(name=variable.name, depth=depth, dim=0)
+
     def write_project_cpp(self, model):
         ###################
         ## myproject.cpp
@@ -88,12 +115,6 @@ class VivadoWriter(Writer):
                 newline += indent + insize_str + ',\n'
                 newline += indent + outsize_str + '\n'
 
-            elif '//hls-fpga-machine-learning insert weights' in line:
-                newline = line
-                for layer in model.get_layers():
-                    for w in layer.get_weights():
-                        newline += '#include "weights/{}.h"\n'.format(w.name)
-
             elif '//hls-fpga-machine-learning insert load weights' in line:
                 newline = line
                 for layer in model.get_layers():
@@ -108,16 +129,25 @@ class VivadoWriter(Writer):
                 newline = line
                 all_inputs = [i.cppname for i in model_inputs]
                 all_outputs = [o.cppname for o in model_outputs]
+
+                for i in model_inputs: newline += indent + self._make_array_pragma(i) + '\n'
+                for o in model_outputs: newline += indent + self._make_array_pragma(o) + '\n'
+
+                interface_mode = model.config.get_config_value('InterfaceMode')
+                if interface_mode is None:
+                    if model.config.get_config_value('IOType') == 'io_parallel':
+                        interface_mode = 'ap_vld'
+                    elif model.config.get_config_value('IOType') == 'io_serial':
+                        interface_mode = 'axis'
+                        
+                newline += indent + '#pragma HLS INTERFACE {} port={},{} \n'.format(interface_mode, ','.join(all_inputs), ','.join(all_outputs))
+
                 if model.config.get_config_value("IOType") == "io_parallel":
-                    for i in model_inputs: newline += indent + '#pragma HLS ARRAY_RESHAPE variable={} complete dim=0 \n'.format(i.cppname)
-                    for o in model_outputs: newline += indent + '#pragma HLS ARRAY_RESHAPE variable={} complete dim=0 \n'.format(o.cppname)
-                    newline += indent + '#pragma HLS INTERFACE ap_vld port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
                     if model.config.model_strategy == 'Resource':
                         newline += indent + '#pragma HLS DATAFLOW \n'
                     else:
                         newline += indent + '#pragma HLS PIPELINE \n'
-                if model.config.get_config_value("IOType") == "io_serial":
-                    newline += indent + '#pragma HLS INTERFACE axis port={},{} \n'.format(','.join(all_inputs), ','.join(all_outputs))
+                elif model.config.get_config_value('IOType') == 'io_serial':
                     newline += indent + '#pragma HLS DATAFLOW \n'
 
                 inval_str = '\n    '.join(['const_size_in_{} = {};'.format(i, inp.size_cpp()) for i, inp in enumerate(model_inputs, 1)])
@@ -138,7 +168,7 @@ class VivadoWriter(Writer):
                             if def_cpp is not None:
                                 newline += '    ' + def_cpp + ';\n'
                                 if var.pragma:
-                                    newline += '    ' + var.pragma + '\n'
+                                    newline += '    ' + self._make_array_pragma(var) + '\n'
                     func = layer.function_cpp()
                     if func:
                         for line in func:
@@ -192,10 +222,10 @@ class VivadoWriter(Writer):
         f.close()
         fout.close()
 
-    def write_parameters(self, model):
+    def write_defines(self, model):
         filedir = os.path.dirname(os.path.abspath(__file__))
-        f = open(os.path.join(filedir,'../templates/vivado/firmware/parameters.h'),'r')
-        fout = open('{}/firmware/parameters.h'.format(model.config.get_output_dir()),'w')
+        f = open(os.path.join(filedir,'../templates/vivado/firmware/defines.h'),'r')
+        fout = open('{}/firmware/defines.h'.format(model.config.get_output_dir()),'w')
 
         for line in f.readlines():
 
@@ -213,6 +243,30 @@ class VivadoWriter(Writer):
                     all_precision.update(layer_precision)
                 for used_type in all_precision.values():
                     newline += used_type.definition_cpp()
+
+            else:
+                newline = line
+            fout.write(newline)
+        f.close()
+        fout.close()
+
+    def write_parameters(self, model):
+        filedir = os.path.dirname(os.path.abspath(__file__))
+        f = open(os.path.join(filedir,'../templates/vivado/firmware/parameters.h'),'r')
+        fout = open('{}/firmware/parameters.h'.format(model.config.get_output_dir()),'w')
+
+        for line in f.readlines():
+
+            if '//hls-fpga-machine-learning insert includes' in line:
+                newline = line
+                for include in sorted(set(sum((layer.include_list for layer in model.get_layers()), []))):
+                    newline += '#include "%s"\n' % include
+
+            elif '//hls-fpga-machine-learning insert weights' in line:
+                newline = line
+                for layer in model.get_layers():
+                    for w in layer.get_weights():
+                        newline += '#include "weights/{}.h"\n'.format(w.name)
 
             elif "//hls-fpga-machine-learning insert layer-config" in line:
                 newline = line
@@ -293,24 +347,26 @@ class VivadoWriter(Writer):
                 newline = line.replace('myproject', model.config.get_project_name())
             elif '//hls-fpga-machine-learning insert data' in line:
                 newline = line
+                newline += '      std::vector<float>::const_iterator in_begin = in.begin();\n'
+                newline += '      std::vector<float>::const_iterator in_end;\n'
                 for inp in model.get_input_variables():
-                    input_str = '      ' + inp.definition_cpp() + ' = {};\n'
-                    default_val = ','.join('in[{}]'.format(i) for i in range(inp.size()))
-                    newline += input_str.format('{' + default_val + '}')
+                    newline += '      ' + inp.definition_cpp() + ';\n'
+                    newline += '      in_end = in_begin + ({});\n'.format(inp.size_cpp())
+                    newline += '      std::copy(in_begin, in_end, {});\n'.format(inp.cppname)
+                    newline += '      in_begin = in_end;\n'
                 for out in model.get_output_variables():
-                    output_str = '      ' + out.definition_cpp() + ' = {};\n'
-                    default_val = ','.join(str(o) for o in [0] * out.size())
-                    newline += output_str.format('{' + default_val + '}')
+                    # brace-init zeros the array out because we use std=c++0x
+                    newline += '      ' + out.definition_cpp() + '{};\n'
+                    # but we can still explicitly zero out if you want
+                    newline += '      std::fill_n({}, {}, 0.);\n'.format(out.cppname, out.size())
             elif '//hls-fpga-machine-learning insert zero' in line:
                 newline = line
                 for inp in model.get_input_variables():
-                    input_str = '    ' + inp.definition_cpp() + ' = {};\n'
-                    default_val = ','.join(str(i) for i in [0] * inp.size())
-                    newline += input_str.format('{' + default_val + '}')
+                    newline += '    ' + inp.definition_cpp() + ';\n'
+                    newline += '    std::fill_n({}, {}, 0.);\n'.format(inp.cppname, inp.size_cpp())
                 for out in model.get_output_variables():
-                    output_str = '    ' + out.definition_cpp() + ' = {};\n'
-                    default_val = ','.join(str(o) for o in [0] * out.size())
-                    newline += output_str.format('{' + default_val + '}')
+                    newline += '    ' + out.definition_cpp() + '{};\n'
+                    newline += '      std::fill_n({}, {}, 0.);\n'.format(out.cppname, out.size())
             elif '//hls-fpga-machine-learning insert top-level-function' in line:
                 newline = line
 
@@ -421,6 +477,7 @@ class VivadoWriter(Writer):
         self.write_project_cpp(model)
         self.write_project_header(model)
         self.write_weights(model)
+        self.write_defines(model)
         self.write_parameters(model)
         self.write_test_bench(model)
         self.write_build_script(model)


### PR DESCRIPTION
- C++ template reorganization: I wanted parameters.h to include the weights for GarNet (so that the config structs can refer to the weight arrays). To make this happen, header inclusions in the C++ templates have been shuffled:
    - Added a new file defines.h that has the `hls-fpga-machine-learning insert numbers` and `hls-fpga-machine-learning insert layer-precision` lines (originally in parameters.h)
    - Line `hls-fpga-machine-learning insert weights` is now in parameters.h
    - myproject.h includes defines.h
    - myproject.cpp includes parameters.h
    - myproject_test.cpp does not include parameters.h any more (it only needed the number macros and typedefs, which are now in defines.h and are included through myproject.h)
- "include list": Making the list of included nnet_utils files model-specific.
    - Added an attribute `include_list` to the class `Layer` in hls_model.py
    - The layer include list is set in templates/vivado_template.py (with functions defined in templates/templates.py)
    - Added a template line `hls-fpga-machine-learning insert includes` to templates/vivado/firmware/parameters.h
    - keras_writer.py collects the layer include lists, uniqify them, and inserts the list to this template line in parameters.h
- Array partitioning and reshape: Allowing layers in hls_model.py to specify how they want to partition / reshape the input and output arrays.
    - I suppose we don't want the vivado-specific `#pragma HLS ...` lines in hls_model.py any more (lines 375-393).
    - Instead we should just set the `pragma` attribute of each ArrayVariable object to simple keywords of `'partition'`, `'reshape'`, or `'stream'`, or to a tuple (`'partition/reshape'`, `'complete/cyclic/block'`[, factor]) in case of incomplete partitioning or reshaping.
    - vivado_writer.py then should pick this config up and form the `#pragma HLS ...` lines (added a helper function `_make_array_pragma`).
- hls_model.py made compatible with multiple input layers: lines 679-685. Type for _i_th input array (_i_ != 1) is named `input[i]_t`
- Cosmetics in myproject_test.cpp: Using `std::copy` and `std::fill_n` to set the input and output array values