### PR TITLE
Stable softmax

### DIFF
--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -698,6 +698,8 @@ class Softmax(Activation):
                 self.set_attr('exp_table_t', self.get_attr('table_t'))
             if 'inv_table_t' not in self.attributes:
                 self.set_attr('inv_table_t', self.get_attr('table_t'))
+            if 'implementation' not in self.attributes:
+                self.set_attr('implementation', 'latency')
 
 class BatchNormalization(Layer):
     def initialize(self):

--- a/hls4ml/model/hls_layers.py
+++ b/hls4ml/model/hls_layers.py
@@ -698,8 +698,11 @@ class Softmax(Activation):
                 self.set_attr('exp_table_t', self.get_attr('table_t'))
             if 'inv_table_t' not in self.attributes:
                 self.set_attr('inv_table_t', self.get_attr('table_t'))
-            if 'implementation' not in self.attributes:
+            if self.model.config.is_resource_strategy(self):
+                # 'resource' strategy = 'latency' for Softmax
                 self.set_attr('implementation', 'latency')
+            else:
+                self.set_attr('implementation', self.model.config.get_strategy(self).lower())
 
 class BatchNormalization(Layer):
     def initialize(self):

--- a/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
+++ b/hls4ml/templates/vivado/nnet_utils/nnet_activation.h
@@ -174,6 +174,9 @@ void  sigmoid(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
 // *************************************************
 //       Softmax Activation
 // *************************************************
+
+enum softmax_implementation {latency=0, legacy=1, stable=2};
+
 inline float exp_fcn_float(float input) {
     return std::exp(input);
 }
@@ -217,7 +220,50 @@ void init_invert_table(typename CONFIG_T::inv_table_t table_out[CONFIG_T::table_
 }
 
 template <class data_T, class res_T, typename CONFIG_T>
-void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+void softmax_latency(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+    // Initialize the lookup tables
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
+    typename CONFIG_T::inv_table_t invert_table[CONFIG_T::table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::exp_table_t exp_table[CONFIG_T::table_size];
+    static typename CONFIG_T::inv_table_t invert_table[CONFIG_T::table_size];
+
+#endif
+    if (!initialized) {
+        // Note we are exponentiating the inputs, which have type data_T
+        init_exp_table<data_T, CONFIG_T>(exp_table);
+        // Note we are inverting the exponentials, which have type exp_table_t
+        init_invert_table<typename CONFIG_T::exp_table_t, CONFIG_T>(invert_table);
+        initialized = true;
+    }
+
+    // Calculate all the e^x's
+    typename CONFIG_T::exp_table_t exp_res[CONFIG_T::n_in];
+	#pragma HLS array_partition variable=exp_res complete
+    typename CONFIG_T::exp_table_t exp_sum(0);
+    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+        #pragma HLS unroll
+    	unsigned x = softmax_idx_from_real_val<data_T, CONFIG_T>(data[i]);
+        exp_res[i] = exp_table[x];
+    }
+
+    // Explicitly sum the results with an adder tree.
+    // Rounding & Saturation mode, which improve accuracy, prevent Vivado from expression balancing
+    Op_add<typename CONFIG_T::exp_table_t> op_add;
+    exp_sum = reduce<typename CONFIG_T::exp_table_t, CONFIG_T::n_in, Op_add<typename CONFIG_T::exp_table_t>>(exp_res, op_add);
+
+    typename CONFIG_T::inv_table_t inv_exp_sum = invert_table[softmax_idx_from_real_val<typename CONFIG_T::exp_table_t,CONFIG_T>(exp_sum)];
+    for(unsigned i = 0; i < CONFIG_T::n_in; i++){
+        #pragma HLS unroll
+        res[i] = exp_res[i] * inv_exp_sum;
+    }
+}
+
+template <class data_T, class res_T, typename CONFIG_T>
+void softmax_stable(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
     // Initialize the lookup tables
 #ifdef __HLS_SYN__
     bool initialized = false;
@@ -241,7 +287,8 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
     Op_max<data_T> op_max;
     data_T x_max = reduce<data_T, CONFIG_T::n_in, Op_max<data_T>>(data, op_max);
 
-    ap_fixed<16,6,AP_RND,AP_SAT> d_xi_xmax[CONFIG_T::n_in];
+    // For the diffs, use the same type as the input but force rounding and saturation
+    ap_fixed<data_T::width, data_T::iwidth,AP_RND,AP_SAT> d_xi_xmax[CONFIG_T::n_in];
     for(unsigned i = 0; i < CONFIG_T::n_in; i++){
         #pragma HLS unroll
         d_xi_xmax[i] = data[i] - x_max;
@@ -267,6 +314,110 @@ void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
         #pragma HLS unroll
         res[i] = exp_res[i] * inv_exp_sum;
     }
+}
+
+template<typename CONFIG_T, int N_TABLE>
+void init_exp_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
+{
+    for (int ii = 0; ii < N_TABLE; ii++) {
+        // First, convert from table index to X-value (signed 8-bit, range -8 to +8)
+        float in_val = 2*8.0*(ii-float(N_TABLE)/2.0)/float(N_TABLE);
+        // Next, compute lookup table function
+        typename CONFIG_T::table_t real_val = exp_fcn_float(in_val);
+        //std::cout << "Lookup table In Value: " << in_val << " Result: " << real_val << std::endl;
+        table_out[ii] = real_val;
+    }
+}
+
+template<typename CONFIG_T, int N_TABLE>
+void init_invert_table_legacy(typename CONFIG_T::table_t table_out[N_TABLE])
+{
+    // Inversion function:
+    //   result = 1/x
+    for (int ii = 0; ii < N_TABLE; ii++) {
+      // First, convert from table index to X-value (signed 8-bit, range 0 to +64)
+	float in_val = 64.0*ii/float(N_TABLE);
+        // Next, compute lookup table function
+	if (in_val > 0.0) table_out[ii] = 1.0/in_val;
+	else table_out[ii] = 0.0;
+    }
+}
+
+template<class data_T, class res_T, typename CONFIG_T>
+void  softmax_legacy(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in])
+{
+    // Initialize the lookup table
+#ifdef __HLS_SYN__
+    bool initialized = false;
+    typename CONFIG_T::table_t exp_table[CONFIG_T::table_size];
+    typename CONFIG_T::table_t invert_table[CONFIG_T::table_size];
+#else
+    static bool initialized = false;
+    static typename CONFIG_T::table_t exp_table[CONFIG_T::table_size];
+    static typename CONFIG_T::table_t invert_table[CONFIG_T::table_size];
+#endif
+    if (!initialized) {
+        init_exp_table_legacy<CONFIG_T, CONFIG_T::table_size>(exp_table);
+        init_invert_table_legacy<CONFIG_T, CONFIG_T::table_size>(invert_table);
+        initialized = true;
+    }
+
+    if (CONFIG_T::io_type == io_parallel){
+        // Note: This is going to be a resource hog to run with pipeline, but hey, whatever
+        #pragma HLS PIPELINE
+    }
+
+    // Index into the lookup table based on data for exponentials
+    typename CONFIG_T::table_t exp_res[CONFIG_T::n_in];// different, independent, fixed point precision
+    typename CONFIG_T::table_t exp_diff_res;// different, independent, fixed point precision
+    data_T data_cache[CONFIG_T::n_in];
+    int data_round;
+    int index;
+    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+      data_cache[ii] = data[ii];
+      exp_res[ii] = 0;
+    }
+    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+      if (CONFIG_T::io_type == io_serial){
+          #pragma HLS PIPELINE
+      }
+      for (int jj=0; jj<CONFIG_T::n_in; jj++) {
+	if (ii==jj) exp_diff_res = 1;
+	else {
+	  data_round = (data_cache[jj]-data_cache[ii])*CONFIG_T::table_size/16;
+	  index = data_round + 8*CONFIG_T::table_size/16;
+	  if (index < 0)   index = 0;
+	  if (index > CONFIG_T::table_size-1) index = CONFIG_T::table_size-1;
+	  exp_diff_res = exp_table[index];
+	}
+	exp_res[ii] += exp_diff_res;
+      }
+    }
+
+    //Second loop to invert
+    for (int ii=0; ii<CONFIG_T::n_in; ii++) {
+      int exp_res_index = exp_res[ii]*CONFIG_T::table_size/64;
+      if (exp_res_index < 0)   exp_res_index = 0;
+      if (exp_res_index > CONFIG_T::table_size-1) exp_res_index = CONFIG_T::table_size-1;
+      //typename CONFIG_T::table_t exp_res_invert = invert_table[exp_res_index];
+      res[ii] = (res_T) invert_table[exp_res_index];
+    }
+
+}
+
+template<class data_T, class res_T, typename CONFIG_T>
+void softmax(data_T data[CONFIG_T::n_in], res_T res[CONFIG_T::n_in]){
+    switch(CONFIG_T::implementation){
+    case latency:
+        softmax_latency<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case stable:
+        softmax_stable<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    case legacy:
+        softmax_legacy<data_T, res_T, CONFIG_T>(data, res);
+        break;
+    }    
 }
 
 // *************************************************

--- a/hls4ml/templates/vivado_template.py
+++ b/hls4ml/templates/vivado_template.py
@@ -93,6 +93,7 @@ softmax_config_template = """struct {type}_config{index} : nnet::activ_config {{
     static const unsigned table_size = {table_size};
     static const unsigned io_type = nnet::{iotype};
     static const unsigned reuse_factor = {reuse};
+    static const nnet::softmax_implementation implementation = nnet::softmax_implementation::{implementation};
     typedef {exp_table_t} exp_table_t;
     typedef {inv_table_t} inv_table_t;
 }};\n"""

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -147,7 +147,6 @@ def config_from_keras_model(model, granularity='model', default_precision='ap_fi
             if layer['config']['activation'] == 'softmax':
                layer_config['exp_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
                layer_config['inv_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
-               layer_config['implementation'] = 'latency'
             else:
                 layer_config['table_t'] = 'ap_fixed<18,8>'
         

--- a/hls4ml/utils/config.py
+++ b/hls4ml/utils/config.py
@@ -144,9 +144,10 @@ def config_from_keras_model(model, granularity='model', default_precision='ap_fi
             layer_config['Precision'] = default_precision
             layer_config['ReuseFactor'] = default_reuse_factor
             layer_config['table_size'] = 1024
-            if layer['class_name'] == 'Softmax':
-               layer_config['exp_table_t'] = 'ap_fixed<18,8>'
-               layer_config['inv_table_t'] = 'ap_fixed<18,8>'
+            if layer['config']['activation'] == 'softmax':
+               layer_config['exp_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
+               layer_config['inv_table_t'] = 'ap_fixed<18,8,AP_RND,AP_SAT>'
+               layer_config['implementation'] = 'latency'
             else:
                 layer_config['table_t'] = 'ap_fixed<18,8>'
         


### PR DESCRIPTION
I've a bit more for the Softmax implementation. You may recall there was a new version introduced with PR #195.
In issue #204, it was observed to not be working that well, possibly resulting in unphysical values (out of the range {0,1}) and giving incorrect predictions.

After some more experiments, I've done a few things:
- Changed the default type (when using `hls4ml.util.config`) to include the `AP_RND`, `AP_SAT` rounding and saturation modes. This bounds the values to the correct range
- Added a new 'stable' implementation (documented below)
- Added a config parameter to select between implementations
- Based on the above parameter, added back the implementation used until v0.2.0 (now called 'legacy')

The new 'stable' version uses the same type-agnostic lookup tables as the recent new implementation. For the vector `x`, Softmax does: `y = exp(x) / sum(exp(x))`. In the code, lookup tables are used for `exp(x)` and `1 / exp(x)`. The new version does `y = exp(x - max(x)) / sum(exp(x - max(x)))`. This construction means that all the `x - max(x)` values are either `0` (when `x = max(x)`) or negative. This makes the lookup tables much nicer. The exponential table effectively saturates at the ~0 end rather than the +infinity end like just looking up `exp(x)`.

On the jet tagging dataset, the version in master already performs well, and the new stable implementation performs similarly (just showing 2 classes for clarity):
![roc](https://user-images.githubusercontent.com/14807534/88420628-773f5480-cde7-11ea-8e86-f45626016f7f.png)

The problem was seen in MNIST, where the accuracy is typically close to 100%. This means one class is typically predicted with a much greater probability than any other. Most of the time the implementation in `master` works fine, but due to the big range in input values, sometimes class predictions which are actually quite different get clipped to the same probability (~1). Then when taking the `argmax` to predict and evaluate accuracy, the wrong prediction can be made. The new 'stable' implementation resolves these nicely.
Here's the ROC just for one class:

![ROC_mnist](https://user-images.githubusercontent.com/14807534/88420446-33e4e600-cde7-11ea-9b79-8c10a020524f.png)

It may look like it's still not doing that well, but the accuracy tells the story:

| Inference | Accuracy |
| --- | --- |
| Keras |   0.9774 |
| Master |   0.9720 |
| Legacy |  0.9689 |
| Stable |    0.9774 |

So the `argmax` prediction matches Keras every time, in this case. The ROC differs slightly because there's not quite so much precision on the hls4ml prediction as the Keras one. 

In terms of latency & resources, the new stable version is very slightly slower than either the current master, or 'legacy' versions due to having to find the `max(x)`: 6 cycles for those vs 8 for the stable in a standalone Softmax project for 10 classes (MNIST).

The resources are most similar to the current master implementation, so `~0%` for all types, but slightly more LUTs and FFs are used. Both these are smaller than the legacy implementation.

So based on the latency & resources I've set the default implementation to be the one in current master (called `latency`). 
The selection is done in the config like `cfg['LayerName']['softmax']['implementation'] = 'stable'` (options are `latency, stable, legacy`). We might want to make the default `stable` to 'just work' in more cases, but for low latency applications the `latency` version is probably best.