### PR TITLE
Fix to unscaling/rescaling of bias in QKeras case with alpha != 1

### DIFF
--- a/hls4ml/model/optimizer/passes/qkeras.py
+++ b/hls4ml/model/optimizer/passes/qkeras.py
@@ -150,7 +150,7 @@ class QKerasFactorizeAlpha(OptimizerPass):
             'n_filt' : node.get_attr('n_filt') if node.get_attr('n_filt') is not None else -1,
             'reuse_factor' : node.get_attr('reuse_factor'),
             'bias_t' : node.weights['bias'].type, 
-            'scale_t' : 'ap_fixed<16,6>' # TODO automate this
+            'scale_t' : FixedPrecisionType() # TODO automate this
         }
         alpha_layer = model.make_node('ApplyAlpha', node.name + '_alpha', attrs, node.outputs)
         alpha_layer.add_weights(scale, quantizer=None)


### PR DESCRIPTION
For QKeras Dense/Conv layers with `alpha != 1`, there is an optimization pass to factorize the scale out of the layer weights, then apply the scale back in an extra layer (`ApplyAlpha`) afterwards. This brings the values of the weights back into the range given by the chosen type.

I observed an issue that the biases were being rescaled by the `ApplyAlpha`, but they had not been unscaled in the first place. This fix moves the addition of the bias from the Dense/Conv layer into the `ApplyAlpha` to be numerically correct. I think adding the bias here rather than also unscaling-then-rescaling it like the weights makes sense to reduce rounding errors.

The operation `y = ApplyAlpha(Dense(x))` was doing `y = (w / s * x + b) * s != w * x + b`. Now we do `y = (w / s * x) * s + b`.