### PR TITLE
Read InputLayer from Sequential models (TF 2.3)

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -173,13 +173,14 @@ def keras_to_hls(config):
         layer_config = model_arch['config']
         if 'layers' in layer_config: # Newer Keras versions have 'layers' in 'config' key
             layer_config = layer_config['layers']
-        # Sequential doesn't have InputLayer
-        input_layer = {}
-        input_layer['name'] = 'input1'
-        input_layer['class_name'] = 'InputLayer'
-        input_layer['input_shape'] = layer_config[0]['config']['batch_input_shape'][1:]
-        layer_list.append(input_layer)
-        print('Input shape:', input_layer['input_shape'])
+        # Sequential doesn't have InputLayer in TF < 2.3 (Keras 2.4.0)
+        if layer_config[0]['class_name'] != 'InputLayer':
+            input_layer = {}
+            input_layer['name'] = 'input1'
+            input_layer['class_name'] = 'InputLayer'
+            input_layer['input_shape'] = layer_config[0]['config']['batch_input_shape'][1:]
+            layer_list.append(input_layer)
+            print('Input shape:', input_layer['input_shape'])
     elif model_arch['class_name'] == 'Model':
         print('Interpreting Model')
         layer_config = model_arch['config']['layers']


### PR DESCRIPTION
Tensorflow 2.3 (Keras 2.4.0) now adds `InputLayer` to `Sequential` models, so we have to make sure we read it, otherwise two inputs will be created and HLS will mess up.