### PR TITLE
Handle no-bias fusing of Dense and BN

### DIFF
--- a/hls4ml/converters/keras_to_hls.py
+++ b/hls4ml/converters/keras_to_hls.py
@@ -116,6 +116,8 @@ def parse_default_keras_layer(keras_layer, input_names):
         layer['activation'] = keras_layer['config']['activation']
     if 'epsilon' in keras_layer['config']:
         layer['epsilon'] = keras_layer['config']['epsilon']
+    if 'use_bias' in keras_layer['config']:
+        layer['use_bias'] = keras_layer['config']['use_bias']
 
     return layer
 

--- a/hls4ml/model/optimizer/passes/dense_bn_fuse.py
+++ b/hls4ml/model/optimizer/passes/dense_bn_fuse.py
@@ -25,7 +25,9 @@ class FuseDenseAndBatchNormalization(OptimizerPass):
         fused_bias = bn_scale.data * dense_bias.data + bn_bias.data
 
         model.remove_node(node, rewire=True)
-        dense_node.weights['weight'].data = fused_weight
-        dense_node.weights['bias'].data = fused_bias
+        dense_weight.data = fused_weight
+        dense_bias.data = fused_bias
+        if not dense_node.get_attr('use_bias', True):
+            dense_bias.update_precision(bn_bias.type.precision)
 
         return True


### PR DESCRIPTION
@vloncar fixed a bug related to Keras layers with `use_bias=False` and the Dense-BatchNorm layer fusion. The 'bias' values from the BatchNorm end up in the Dense layer, but the Dense layer's bias precision is overruled since the Keras layer had `use_bias=False`. Wrong results follow...

Now, in that scenario, the Dense layer (which is now the fused Dense-BatchNorm) picks up the bias precision of the BatchNorm.